### PR TITLE
Add data model for cells

### DIFF
--- a/pydatalab/docs/design/models.md
+++ b/pydatalab/docs/design/models.md
@@ -1,0 +1,56 @@
+# Draft design: Model hierarchy
+
+<style>
+    .route > rect{
+        fill:#FF0000;
+        stroke:#FFFF00;
+        stroke-width:4px;
+    }
+</style>
+
+```mermaid
+classDiagram
+Entry --|> Item
+Entry: str type
+Entry --|> File
+Entry: dict[type_str, dict[enum["parent", "child", "sibling"]], ObjectId] relationships
+class File {
+    str file_id
+    int | None size
+    datetime last_modified
+    datetime last_modified_remote
+    int version
+    str name
+    str extension
+    str original_name
+    str location
+    str url_path
+    str source
+    datetime time_added
+    dict metadata
+    any representation
+    str source_path
+    bool is_live
+}
+class RemoteFilesystem {
+    str name
+    int last_updated
+    str type
+    list~dict~ contents
+}
+Entry --|> RemoteFilesystem
+Material --|> Sample
+Material --|> StartingMaterial
+Item --|> Material
+Sample --o `/samples`
+Item --* `/search-items`
+Sample *-- `/new-sample`
+Sample o-- `/delete-sample`
+class `/delete-sample`:::route
+class `/search-items`:::route
+class `/samples`:::route
+class `/new-sample`:::route
+class `/get-item-data/~item_id~`:::route
+Item --o `/get-item-data/~item_id~`
+Item: str item_id
+```

--- a/pydatalab/pydatalab/models/__init__.py
+++ b/pydatalab/pydatalab/models/__init__.py
@@ -2,11 +2,16 @@ from typing import Dict
 
 from pydantic import BaseModel
 
+from pydatalab.models.cells import Cell
 from pydatalab.models.files import File
 from pydatalab.models.people import Person
 from pydatalab.models.samples import Sample
 from pydatalab.models.starting_materials import StartingMaterial
 
-ITEM_MODELS: Dict[str, BaseModel] = {"samples": Sample, "starting_materials": StartingMaterial}
+ITEM_MODELS: Dict[str, BaseModel] = {
+    "samples": Sample,
+    "starting_materials": StartingMaterial,
+    "cells": Cell,
+}
 
 __all__ = ("File", "Sample", "StartingMaterial", "Person", "ITEM_MODELS")

--- a/pydatalab/pydatalab/models/cells.py
+++ b/pydatalab/pydatalab/models/cells.py
@@ -1,0 +1,70 @@
+from enum import Enum
+from typing import List, Optional, Union
+
+from pydantic import BaseModel, Field, validator
+
+from pydatalab.models.entries import EntryReference
+from pydatalab.models.items import Item
+from pydatalab.models.samples import Constituent
+
+
+class CellFormat(str, Enum):
+
+    coin = "coin"
+    pouch = "pouch"
+    in_situ_xrd = "in situ (XRD)"
+    in_situ_nmr = "in situ (NMR)"
+    in_situ_squid = "in situ (SQUID)"
+    swagelok = "swagelok"
+    cylindrical = "cylindrical"
+    other = "other"
+
+
+class InlineSubstance(BaseModel):
+    name: str
+    formula: str
+
+
+class CellComponent(Constituent):
+    """A constituent of a sample."""
+
+    item: Union[EntryReference, InlineSubstance] = Field(...)
+    """A reference to item (sample or starting material) entry for the constituent substance."""
+
+
+class Cell(Item):
+    """A model for representing electrochemical cells."""
+
+    type: str = Field("cells", const="cells", pattern="^cells$")
+
+    cell_format: CellFormat = Field(
+        description="The form factor of the cell, e.g., coin, pouch, in situ or otherwise.",
+    )
+
+    cell_format_description: Optional[str] = Field(
+        description="Additional human-readable description of the cell form factor, e.g., 18650, AMPIX, CAMPIX"
+    )
+
+    cell_preparation_description: Optional[str] = Field()
+
+    characteristic_mass: Optional[float] = Field(
+        description="The characteristic mass of the cell in milligrams. Can be used to normalize capacities."
+    )
+
+    positive_electrode: List[CellComponent] = Field([])
+
+    negative_electrode: List[CellComponent] = Field([])
+
+    electrolyte: List[CellComponent] = Field([])
+
+    active_ion_charge: float = Field(1)
+
+    @validator("cell_format", "cell_format_description")
+    def check_descriptions_for_ambiguous_formats(cls, v, values):
+        if (
+            values.get("cell_format") == CellFormat.other
+            and values.get("cell_format_description") is None
+        ):
+            raise ValueError("cell_format_description must be set if cell_format is 'other'")
+
+        return v

--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -10,7 +10,8 @@ from pydantic import ValidationError
 from pydatalab.blocks import BLOCK_TYPES
 from pydatalab.config import CONFIG
 from pydatalab.logger import LOGGER
-from pydatalab.models import ITEM_MODELS, Sample
+from pydatalab.models import ITEM_MODELS
+from pydatalab.models.items import Item
 from pydatalab.models.relationships import RelationshipType
 from pydatalab.mongo import flask_mongo
 from pydatalab.routes.utils import get_default_permissions
@@ -201,7 +202,7 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
         return (
             dict(
                 status="error",
-                message="Unable to create new sample without user authentication.",
+                message="Unable to create new item without user authentication.",
                 item_id=sample_dict["item_id"],
             ),
             401,
@@ -216,7 +217,7 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
             return (
                 dict(
                     status="error",
-                    message=f"Request to copy sample with id {copy_from_item_id} failed because sample could not be found.",
+                    message=f"Request to copy item with id {copy_from_item_id} failed because item could not be found.",
                     item_id=sample_dict["item_id"],
                 ),
                 404,
@@ -229,7 +230,7 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
             return (
                 dict(
                     status="error",
-                    message=f"Request to copy sample with id {copy_from_item_id} to new item failed because the target new item_id was not provided.",
+                    message=f"Request to copy item with id {copy_from_item_id} to new item failed because the target new item_id was not provided.",
                 ),
                 400,
             )
@@ -239,27 +240,37 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
 
         # any provided constituents will be added to the synthesis information table in
         # addition to the constituents copied from the copy_from_item_id, avoiding duplicates
-        existing_consituent_ids = [
-            constituent["item"]["item_id"] for constituent in copied_doc["synthesis_constituents"]
-        ]
-        copied_doc["synthesis_constituents"] += [
-            constituent
-            for constituent in sample_dict.get("synthesis_constituents", [])
-            if (constituent["item"]["item_id"] not in existing_consituent_ids)
-        ]
+        if copied_doc["type"] == "samples":
+            existing_consituent_ids = [
+                constituent["item"]["item_id"]
+                for constituent in copied_doc["synthesis_constituents"]
+            ]
+            copied_doc["synthesis_constituents"] += [
+                constituent
+                for constituent in sample_dict.get("synthesis_constituents", [])
+                if (constituent["item"]["item_id"] not in existing_consituent_ids)
+            ]
+            sample_dict = copied_doc
 
-        sample_dict = copied_doc
+        elif copied_doc["type"] == "cells":
+            for component in ("cathode", "anode", "electrolyte"):
+                if copied_doc.get(component):
+                    existing_consituent_ids = [
+                        constituent["item"]["item_id"] for constituent in copied_doc[component]
+                    ]
+                    copied_doc[component] += [
+                        constituent
+                        for constituent in sample_dict.get(component, [])
+                        if (constituent["item"]["item_id"] not in existing_consituent_ids)
+                    ]
 
-    schema = Sample.schema()
-    missing_keys = set()
-    for k in schema.get("required", []):
-        if k not in sample_dict:
-            missing_keys.add(k)
+            sample_dict = copied_doc
 
-    if missing_keys:
-        raise ValidationError(
-            f"Request to create sample was thwarted by the lack of required key(s): {missing_keys}"
-        )
+    type = sample_dict["type"]
+    if type not in ITEM_MODELS:
+        raise RuntimeError("Invalid type")
+    model = ITEM_MODELS[type]
+    schema = model.schema()
 
     new_sample = {k: sample_dict[k] for k in schema["properties"] if k in sample_dict}
 
@@ -290,25 +301,25 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
 
     new_sample["date"] = new_sample.get("date", datetime.datetime.now())
     try:
-        new_sample = Sample(**new_sample)
+        data_model: Item = model(**new_sample)
 
     except ValidationError as error:
         return (
             dict(
                 status="error",
-                message=f"Unable to create new sample with ID {new_sample['item_id']}.",
+                message=f"Unable to create new {type} with ID {new_sample['item_id']}.",
                 item_id=new_sample["item_id"],
                 output=str(error),
             ),
             400,
         )
 
-    result = flask_mongo.db.items.insert_one(new_sample.dict())
+    result = flask_mongo.db.items.insert_one(data_model.dict())
     if not result.acknowledged:
         return (
             dict(
                 status="error",
-                message=f"Failed to add new sample {new_sample.item_id!r} to database.",
+                message=f"Failed to add new {type} {new_sample['item_id']!r} to database.",
                 item_id=new_sample["item_id"],
                 output=result.raw_result,
             ),
@@ -318,16 +329,17 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
     return (
         {
             "status": "success",
-            "item_id": new_sample.item_id,
+            "item_id": data_model.item_id,
             "sample_list_entry": {
-                "item_id": new_sample.item_id,
+                "item_id": data_model.item_id,
                 "nblocks": 0,
-                "date": new_sample.date,
-                "name": new_sample.name,
-                "creator_ids": new_sample.creator_ids,
-                "creators": [json.loads(c.json()) for c in new_sample.creators]
-                if new_sample.creators
+                "date": data_model.date,
+                "name": data_model.name,
+                "creator_ids": data_model.creator_ids,
+                "creators": [json.loads(c.json()) for c in data_model.creators]
+                if data_model.creators
                 else [],
+                "type": data_model.type,
             },
         },
         201,  # 201: Created

--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -307,7 +307,7 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
         return (
             dict(
                 status="error",
-                message=f"Unable to create new {type} with ID {new_sample['item_id']}.",
+                message=f"Unable to create new item with ID {new_sample['item_id']}.",
                 item_id=new_sample["item_id"],
                 output=str(error),
             ),
@@ -319,7 +319,7 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
         return (
             dict(
                 status="error",
-                message=f"Failed to add new {type} {new_sample['item_id']!r} to database.",
+                message=f"Failed to add new item {new_sample['item_id']!r} to database.",
                 item_id=new_sample["item_id"],
                 output=result.raw_result,
             ),

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -1,0 +1,410 @@
+{
+  "title": "Cell",
+  "description": "A model for representing electrochemical cells.",
+  "type": "object",
+  "properties": {
+    "type": {
+      "title": "Type",
+      "default": "cells",
+      "const": "cells",
+      "pattern": "^cells$",
+      "type": "string"
+    },
+    "immutable_id": {
+      "title": "Immutable ID",
+      "type": "string"
+    },
+    "last_modified": {
+      "title": "Last Modified",
+      "type": "date",
+      "format": "date-time"
+    },
+    "relationships": {
+      "title": "Relationships",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/TypedRelationship"
+      }
+    },
+    "revision": {
+      "title": "Revision",
+      "default": 1,
+      "type": "integer"
+    },
+    "revisions": {
+      "title": "Revisions",
+      "type": "object"
+    },
+    "item_id": {
+      "title": "Item Id",
+      "minLength": 1,
+      "maxLength": 40,
+      "pattern": "^[a-zA-Z0-9_-]+$",
+      "type": "string"
+    },
+    "creator_ids": {
+      "title": "Creator Ids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "creators": {
+      "title": "Creators",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Person"
+      }
+    },
+    "description": {
+      "title": "Description",
+      "type": "string"
+    },
+    "date": {
+      "title": "Date",
+      "type": "date",
+      "format": "date-time"
+    },
+    "name": {
+      "title": "Name",
+      "type": "string"
+    },
+    "blocks_obj": {
+      "title": "Blocks Obj",
+      "default": {},
+      "type": "object"
+    },
+    "display_order": {
+      "title": "Display Order",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "files": {
+      "title": "Files",
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "file_ObjectIds": {
+      "title": "File Objectids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "cell_format": {
+      "description": "The form factor of the cell, e.g., coin, pouch, in situ or otherwise.",
+      "allOf": [
+        {
+          "$ref": "#/definitions/CellFormat"
+        }
+      ]
+    },
+    "cell_format_description": {
+      "title": "Cell Format Description",
+      "description": "Additional human-readable description of the cell form factor, e.g., 18650, AMPIX, CAMPIX",
+      "type": "string"
+    },
+    "cell_preparation_description": {
+      "title": "Cell Preparation Description",
+      "type": "string"
+    },
+    "characteristic_mass": {
+      "title": "Characteristic Mass",
+      "description": "The characteristic mass of the cell in milligrams. Can be used to normalize capacities.",
+      "type": "number"
+    },
+    "positive_electrode": {
+      "title": "Positive Electrode",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/CellComponent"
+      }
+    },
+    "negative_electrode": {
+      "title": "Negative Electrode",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/CellComponent"
+      }
+    },
+    "electrolyte": {
+      "title": "Electrolyte",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/CellComponent"
+      }
+    },
+    "active_ion_charge": {
+      "title": "Active Ion Charge",
+      "default": 1,
+      "type": "number"
+    }
+  },
+  "required": [
+    "item_id",
+    "cell_format"
+  ],
+  "definitions": {
+    "RelationshipType": {
+      "title": "RelationshipType",
+      "description": "An enumeration of the possible types of relationship between two entries.\n\n```mermaid\nclassDiagram\nclass entryC\nentryC --|> entryA: parent\nentryC ..|> entryD\nentryA <..> entryD: sibling\nentryA --|> entryB : child\n```",
+      "enum": [
+        "parent",
+        "child",
+        "sibling",
+        "is_part_of",
+        "other"
+      ],
+      "type": "string"
+    },
+    "KnownType": {
+      "title": "KnownType",
+      "description": "An enumeration of the types of entry known by this implementation, should be made dynamic in the future.",
+      "enum": [
+        "samples",
+        "starting_materials",
+        "blocks",
+        "files",
+        "people"
+      ],
+      "type": "string"
+    },
+    "TypedRelationship": {
+      "title": "TypedRelationship",
+      "type": "object",
+      "properties": {
+        "description": {
+          "title": "Description",
+          "description": "A description of the relationship.",
+          "type": "string"
+        },
+        "relation": {
+          "description": "The type of relationship between the two items. If the type is 'other', then a human-readable description should be provided.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/RelationshipType"
+            }
+          ]
+        },
+        "type": {
+          "description": "The type of the related resource.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/KnownType"
+            }
+          ]
+        },
+        "immutable_id": {
+          "title": "Immutable Id",
+          "description": "The immutable ID of the entry that is related to this entry.",
+          "type": "string"
+        },
+        "item_id": {
+          "title": "Item Id",
+          "description": "The ID of the entry that is related to this entry.",
+          "minLength": 1,
+          "maxLength": 40,
+          "pattern": "^[a-zA-Z0-9_-]+$",
+          "type": "string"
+        }
+      },
+      "required": [
+        "relation",
+        "type"
+      ]
+    },
+    "IdentityType": {
+      "title": "IdentityType",
+      "description": "A string enum representing the supported verifiable identity types.",
+      "enum": [
+        "email",
+        "orcid",
+        "github"
+      ],
+      "type": "string"
+    },
+    "Identity": {
+      "title": "Identity",
+      "description": "A model for identities that can be provided by external systems\nand associated with a given user.",
+      "type": "object",
+      "properties": {
+        "identity_type": {
+          "$ref": "#/definitions/IdentityType"
+        },
+        "identifier": {
+          "title": "Identifier",
+          "type": "string"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "verified": {
+          "title": "Verified",
+          "default": false,
+          "type": "boolean"
+        },
+        "display_name": {
+          "title": "Display Name",
+          "type": "string"
+        }
+      },
+      "required": [
+        "identity_type",
+        "identifier",
+        "name"
+      ]
+    },
+    "Person": {
+      "title": "Person",
+      "description": "A model that describes an individual and their digital identities.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "default": "people",
+          "const": "people",
+          "type": "string"
+        },
+        "immutable_id": {
+          "title": "Immutable ID",
+          "type": "string"
+        },
+        "last_modified": {
+          "title": "Last Modified",
+          "type": "date",
+          "format": "date-time"
+        },
+        "relationships": {
+          "title": "Relationships",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TypedRelationship"
+          }
+        },
+        "revision": {
+          "title": "Revision",
+          "default": 1,
+          "type": "integer"
+        },
+        "revisions": {
+          "title": "Revisions",
+          "type": "object"
+        },
+        "identities": {
+          "title": "Identities",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Identity"
+          }
+        },
+        "display_name": {
+          "title": "Display Name",
+          "type": "string"
+        },
+        "contact_email": {
+          "title": "Contact Email",
+          "type": "string",
+          "format": "email"
+        }
+      }
+    },
+    "CellFormat": {
+      "title": "CellFormat",
+      "description": "An enumeration.",
+      "enum": [
+        "coin",
+        "pouch",
+        "in situ (XRD)",
+        "in situ (NMR)",
+        "in situ (SQUID)",
+        "swagelok",
+        "cylindrical",
+        "other"
+      ],
+      "type": "string"
+    },
+    "EntryReference": {
+      "title": "EntryReference",
+      "description": "A reference to a database entry by ID and type.\n\nCan include additional arbitarary metadata useful for\ninlining the item data.",
+      "type": "object",
+      "properties": {
+        "type": {
+          "title": "Type",
+          "type": "string"
+        },
+        "immutable_id": {
+          "title": "Immutable Id",
+          "type": "string"
+        },
+        "item_id": {
+          "title": "Item Id",
+          "type": "string"
+        }
+      },
+      "required": [
+        "type"
+      ]
+    },
+    "InlineSubstance": {
+      "title": "InlineSubstance",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "formula": {
+          "title": "Formula",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name",
+        "formula"
+      ]
+    },
+    "CellComponent": {
+      "title": "CellComponent",
+      "description": "A constituent of a sample.",
+      "type": "object",
+      "properties": {
+        "item": {
+          "title": "Item",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EntryReference"
+            },
+            {
+              "$ref": "#/definitions/InlineSubstance"
+            }
+          ]
+        },
+        "quantity": {
+          "title": "Quantity",
+          "minimum": 0,
+          "type": "number"
+        },
+        "unit": {
+          "title": "Unit",
+          "default": "g",
+          "type": "string"
+        }
+      },
+      "required": [
+        "item",
+        "quantity"
+      ]
+    }
+  }
+}

--- a/pydatalab/tests/conftest.py
+++ b/pydatalab/tests/conftest.py
@@ -8,16 +8,17 @@ import pytest
 
 import pydatalab.mongo
 from pydatalab.main import create_app
-from pydatalab.models import Sample, StartingMaterial
+from pydatalab.models import Cell, Sample, StartingMaterial
+
+TEST_DATABASE_NAME = "db"
 
 
 class PyMongoMock(mongomock.MongoClient):
     def init_app(self, _, *args, **kwargs):
-        return super().__init__()
+        return super().__init__(MONGO_URI)
 
 
 # Must remain as `db` so that calls to flask_mongo.db remain correct
-TEST_DATABASE_NAME = "db"
 MONGO_URI = f"mongodb://localhost:27017/{TEST_DATABASE_NAME}"
 
 
@@ -104,7 +105,41 @@ def client(real_mongo_client, monkeypatch_session):
 
 @pytest.fixture(scope="module", name="default_sample")
 def fixture_default_sample():
-    return Sample(**{"item_id": "12345", "name": "other_sample", "date": "1970-02-01"})
+    return Sample(
+        **{"item_id": "12345", "name": "other_sample", "date": "1970-02-01", "type": "samples"}
+    )
+
+
+@pytest.fixture(scope="module", name="default_cell")
+def fixture_default_cell(default_sample):
+    return Cell(
+        **{
+            "item_id": "test_cell",
+            "name": "test cell",
+            "date": "1970-02-01",
+            "anode": [
+                {
+                    "item": {"item_id": "test", "chemform": "Li15Si4", "type": "samples"},
+                    "quantity": 2.0,
+                    "unit": "mg",
+                },
+                {
+                    "item": {"item_id": "test", "chemform": "C", "type": "samples"},
+                    "quantity": 2.0,
+                    "unit": "mg",
+                },
+            ],
+            "cathode": [
+                {
+                    "item": {"item_id": "test_cathode", "chemform": "LiCoO2", "type": "samples"},
+                    "quantity": 2000,
+                    "unit": "kg",
+                }
+            ],
+            "cell_format": "swagelok",
+            "type": "cells",
+        }
+    )
 
 
 @pytest.fixture(scope="module", name="complicated_sample")
@@ -117,6 +152,7 @@ def fixture_complicated_sample():
             "name": "complex_sample",
             "date": "1970-02-01",
             "chemform": "Na3P",
+            "type": "samples",
             "synthesis_constituents": [
                 Constituent(
                     **{
@@ -205,3 +241,8 @@ def example_items():
 @pytest.fixture(scope="module", name="default_sample_dict")
 def fixture_default_sample_dict(default_sample):
     return default_sample.dict(exclude_unset=True)
+
+
+@pytest.fixture(scope="module", name="default_cell_dict")
+def fixture_default_cell_dict(default_cell):
+    return default_cell.dict(exclude_unset=True)

--- a/pydatalab/tests/routers/test_samples.py
+++ b/pydatalab/tests/routers/test_samples.py
@@ -306,16 +306,57 @@ def test_copy_from_sample(client, complicated_sample):
 
 
 @pytest.mark.dependency(depends=["test_copy_from_sample"])
+def test_create_multiple_samples(client, complicated_sample):
+
+    samples = [complicated_sample, complicated_sample.copy()]
+    samples[0].item_id = "another_new_complicated_sample"
+    samples[1].item_id = "additional_new_complicated_sample"
+
+    response = client.post(
+        "/new-samples/", json={"new_sample_datas": [json.loads(s.json()) for s in samples]}
+    )
+    assert response.status_code == 207, response.json
+    assert response.json["nsuccess"] == 2, response.json
+    assert response.json["nerror"] == 0
+
+    samples = [
+        Sample(item_id="one_more_new_complicated_sample"),
+        Sample(item_id="and_again_new_complicated_sample"),
+    ]
+
+    response = client.post(
+        "/new-samples/",
+        json={
+            "new_sample_datas": [json.loads(s.json()) for s in samples],
+            "copy_from_item_ids": [
+                "another_new_complicated_sample",
+                "additional_new_complicated_sample",
+            ],
+        },
+    )
+
+    assert response.status_code == 207, response.json
+    assert response.json["nsuccess"] == 2
+    assert response.json["nerror"] == 0
+
+    response = client.get("/get-item-data/one_more_new_complicated_sample")
+    assert response.status_code == 200
+    assert (
+        response.json["item_data"]["synthesis_constituents"][0]["item"]["item_id"]
+        == "starting_material_1"
+    )
+
+
+@pytest.mark.dependency(depends=["test_create_multiple_samples"])
 def test_create_cell(client, default_cell):
 
     response = client.post("/new-sample/", json=json.loads(default_cell.json()))
     assert response.status_code == 201, response.json
     assert response.json["status"] == "success"
 
+    copy_doc = {"item_id": "copy_of_complicated_cell"}
+    copy_request = {"new_sample_data": copy_doc, "copy_from_item_id": default_cell.item_id}
+    response = client.post("/new-sample/", json=copy_request)
 
-#    copy_doc = {"item_id": "copy_of_complicated_sample"}
-# copy_request = {"new_sample_data": copy_doc, "copy_from_item_id": default_cell.item_id}
-# response = client.post("/new-sample/", json=copy_request)
-
-# assert response.status_code == 201, response.json
-# assert response.json["status"] == "success"
+    assert response.status_code == 201, response.json
+    assert response.json["status"] == "success"

--- a/pydatalab/tests/routers/test_samples.py
+++ b/pydatalab/tests/routers/test_samples.py
@@ -303,3 +303,19 @@ def test_copy_from_sample(client, complicated_sample):
         "starting_material_2",
         "starting_material_3",
     ]
+
+
+@pytest.mark.dependency(depends=["test_copy_from_sample"])
+def test_create_cell(client, default_cell):
+
+    response = client.post("/new-sample/", json=json.loads(default_cell.json()))
+    assert response.status_code == 201, response.json
+    assert response.json["status"] == "success"
+
+
+#    copy_doc = {"item_id": "copy_of_complicated_sample"}
+# copy_request = {"new_sample_data": copy_doc, "copy_from_item_id": default_cell.item_id}
+# response = client.post("/new-sample/", json=copy_request)
+
+# assert response.status_code == 201, response.json
+# assert response.json["status"] == "success"

--- a/pydatalab/tests/test_models.py
+++ b/pydatalab/tests/test_models.py
@@ -127,3 +127,24 @@ def test_bad_ids(id):
 
     with pytest.raises(pydantic.ValidationError):
         HumanReadableIdentifier(id)
+
+
+def test_cell_with_inlined_reference():
+    from pydatalab.models.cells import Cell
+    from pydatalab.models.samples import Sample
+
+    anode = Sample(item_id="test_anode", formula="C")
+
+    cell = Cell(
+        item_id="abcd-1-2-3",
+        positive_electrode=[{"item": anode, "quantity": 2}],
+        negative_electrode=[
+            {"item": {"name": "My secret cathode", "formula": "NaCoO2"}, "quantity": 3}
+        ],
+        characteristic_mass=1.2,
+        active_ion="Na+",
+        cell_format="swagelok",
+    )
+
+    assert cell
+    assert Cell(**json.loads(cell.json()))

--- a/webapp/cypress/e2e/batchSampleFeature.cy.js
+++ b/webapp/cypress/e2e/batchSampleFeature.cy.js
@@ -765,8 +765,8 @@ describe("Batch sample creation", () => {
     getSubmitButton().click();
 
     cy.get("[data-testid=batch-modal-container] .callout").should("have.length", 3);
-    cy.contains("Unable to create new sample with ID illegal/id.");
-    cy.contains("Unable to create new sample with ID illegal.id");
+    cy.contains("Unable to create new item with ID illegal/id.");
+    cy.contains("Unable to create new item with ID illegal.id");
     cy.contains("legalID Successfully created.");
   });
 

--- a/webapp/src/components/BatchCreateSampleModal.vue
+++ b/webapp/src/components/BatchCreateSampleModal.vue
@@ -384,6 +384,7 @@ export default {
           item_id: sample.item_id,
           date: sample.date,
           name: sample.name,
+          type: "samples",
           synthesis_constituents: sample.components
             ? sample.components.map((x) => ({ item: x, quantity: null }))
             : [],

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -90,6 +90,7 @@ export function createNewSample(item_id, date, name, startingData = {}, copyFrom
       item_id: item_id,
       date: date,
       name: name,
+      type: "samples",
       ...startingData,
     },
   }).then(function (response_json) {


### PR DESCRIPTION
This PR adds a cell data model that is stored as an item. It is currently created with the `create_sample` endpoint.

https://www.youtube.com/watch?v=ZRcpnM26nJM