### PR TITLE
Intercept flask-dance redirects and point back to HTTP referer

### DIFF
--- a/pydatalab/pydatalab/main.py
+++ b/pydatalab/pydatalab/main.py
@@ -182,7 +182,7 @@ def create_app(config_override: Dict[str, Any] = None) -> Flask:
         return f"""<head>
             <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
             </head>
-            <h2><marquee width="200px"><p style="color: CornflowerBlue">Welcome to pydatalab</marquee></h2>
+            <h2><p style="color: CornflowerBlue">Welcome to pydatalab</p></h2>
 <p>{welcome_string}</p>
 <p>{auth_string}</p>
 <p>{logout_string}</p>

--- a/pydatalab/pydatalab/main.py
+++ b/pydatalab/pydatalab/main.py
@@ -65,16 +65,7 @@ def create_app(config_override: Dict[str, Any] = None) -> Flask:
     def logout():
         """Logs out the local user from the current session."""
         logout_user()
-        if request.environ["HTTP_REFERER"] != request.host:
-            return redirect(request.environ["HTTP_REFERER"])
-        return redirect("/")
-
-    @app.route("/login/authorized")
-    def redirect_authenticated():
-        """Redirects the authenticated user back to where they came from."""
-        if request.environ["HTTP_REFERER"] != request.host:
-            return redirect(request.environ["HTTP_REFERER"])
-        return redirect("/")
+        return redirect(request.environ.get("HTTP_REFERER", "/"))
 
     @app.route("/")
     def index():


### PR DESCRIPTION
Addresses #205, but does not yet close it.

Would be nice to make a login modal to replace the current direct link to `/login/github` that could link to the appropriate OAuth provider endpoints, e.g., "Sign in with Github" and "Sign in with ORCID"