### PR TITLE
Fix sizing of EditPage "save" icon

### DIFF
--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -289,9 +289,9 @@ label,
 }
 
 .navbar-icon {
-  width: 2.5rem;
-  height: 2.5rem;
-  /*padding: 0.3rem;*/
+  width: 1.9rem;
+  height: 1.9rem;
+  padding: 0.3rem;
 }
 
 .unsaved-warning {


### PR DESCRIPTION
Updating font awesome seems to have changed the way this one icon is sized. This change makes it similar to the original size.