### PR TITLE
Fix empty string in float value bug

### DIFF
--- a/webapp/src/field_utils.js
+++ b/webapp/src/field_utils.js
@@ -34,7 +34,7 @@ export function createComputedSetterForItemField(item_field) {
       console.log(value);
       store.commit("updateItemData", {
         item_id: this.item_id,
-        block_data: { [item_field]: value },
+        block_data: { [item_field]: value ? value : null },
       });
     },
   };


### PR DESCRIPTION
closes #308 by making the generic computed getters in `field_utils.js` automatically save null whenever an empty string is provided. This doesn't seem to break any existing functionality that I could find, but we should monitor. 