### PR TITLE
Fix empty string in float value bug, part 2

### DIFF
--- a/webapp/src/field_utils.js
+++ b/webapp/src/field_utils.js
@@ -16,7 +16,7 @@ export function createComputedSetterForBlockField(block_field) {
       store.commit("updateBlockData", {
         item_id: this.item_id,
         block_id: this.block_id,
-        block_data: { [block_field]: value },
+        block_data: { [block_field]: value ? value : null },
       });
     },
   };

--- a/webapp/src/field_utils.js
+++ b/webapp/src/field_utils.js
@@ -34,7 +34,7 @@ export function createComputedSetterForItemField(item_field) {
       console.log(value);
       store.commit("updateItemData", {
         item_id: this.item_id,
-        block_data: { [item_field]: value },
+        block_data: { [item_field]: value ? value : null },
       });
     },
   };


### PR DESCRIPTION
In #309, added a fix that had the item computed setter in field_utils.js automatically replace `""` with `null`. Now, do the same for block fields.