### PR TITLE
Add sortable, paginated data table under `/next`

### DIFF
--- a/webapp/package.json
+++ b/webapp/package.json
@@ -33,6 +33,7 @@
     "vue": "^3.2.4",
     "vue-router": "^4.0.0-0",
     "vue-select": "^4.0.0-beta.6",
+    "vue3-easy-data-table": "^1.5.34",
     "vuex": "^4.0.0-0",
     "webcola": "^3.4.0"
   },

--- a/webapp/src/components/FancySampleTable.vue
+++ b/webapp/src/components/FancySampleTable.vue
@@ -1,0 +1,154 @@
+<template>
+  <div v-if="isSampleFetchError" class="alert alert-danger">
+    Server Error. Sample list not retreived.
+  </div>
+
+  <div class="form-inline col-3 ml-auto mb-2">
+    <div class="form-group">
+      <label for="sample-table-search" class="sr-only">Hello</label>
+      <input
+        id="sample-table-search"
+        type="text"
+        class="form-control"
+        v-model="searchValue"
+        placeholder="search"
+      />
+    </div>
+  </div>
+
+  <Vue3EasyDataTable
+    :headers="headers"
+    :items="samples"
+    :search-value="searchValue"
+    table-class-name="customize-table"
+    header-class-name="customize-table-header"
+    buttons-pagination
+    @click-row="goToEditPage"
+    v-model:items-selected="itemsSelected"
+  >
+    <template #item-date="item">
+      {{ $filters.IsoDatetimeToDate(item.date) }}
+    </template>
+
+    <template #item-chemform="item">
+      <ChemicalFormula :formula="item.chemform" />
+    </template>
+
+    <template #item-creators="item">
+      <Creators :creators="item.creators" />
+    </template>
+  </Vue3EasyDataTable>
+</template>
+
+<script>
+import Vue3EasyDataTable from "vue3-easy-data-table";
+// import { Header, Item } from "vue3-easy-data-table"; // types
+import "vue3-easy-data-table/dist/style.css";
+
+import ChemicalFormula from "@/components/ChemicalFormula";
+import Creators from "@/components/Creators";
+import { getSampleList, deleteSample } from "@/server_fetch_utils.js";
+import crypto from "crypto";
+import { GRAVATAR_STYLE } from "@/resources.js";
+
+export default {
+  data() {
+    return {
+      isSampleFetchError: false,
+      gravatar_style: GRAVATAR_STYLE,
+      sampleTableIsReady: false,
+      itemsSelected: [],
+      headers: [
+        { text: "ID", value: "item_id", sortable: true },
+        { text: "type", value: "type", sortable: true },
+        { text: "Sample name", value: "name", sortable: true },
+        { text: "Formula", value: "chemform", sortable: true },
+        { text: "Date", value: "date", sortable: true },
+        { text: "Creators", value: "creators" },
+        { text: "# of blocks", value: "nblocks", sortable: true },
+      ],
+      searchValue: "",
+    };
+  },
+  computed: {
+    samples() {
+      return this.$store.state.sample_list;
+    },
+  },
+  methods: {
+    md5(value) {
+      // Returns the MD5 hash of the given string.
+      return crypto.createHash("md5").update(value).digest("hex");
+    },
+    goToEditPage(row, event) {
+      // don't actually go to editpage is this click is in the select column, because
+      // that is easy to accidentally do. in future, could try to actuate the checkbox, too.
+      if (event.target.querySelector(".easy-checkbox")) {
+        return null;
+      }
+      // if using a modifier key (ctr, meta, alt), open in new tab
+      // otherwise, go in this tab
+      if (event.ctrl || event.metaKey || event.altKey) {
+        window.open(`/edit/${row.item_id}`, "_blank");
+      } else {
+        this.$router.push(`/edit/${row.item_id}`);
+      }
+    },
+    getSamples() {
+      getSampleList()
+        .then(() => {
+          console.log("sample list received!");
+          this.sampleTableIsReady = true;
+        })
+        .catch(() => {
+          this.isSampleFetchError = true;
+        });
+    },
+    deleteSample(sample) {
+      if (confirm(`Are you sure you want to delete sample "${sample.item_id}"?`)) {
+        console.log("deleting...");
+        deleteSample(sample.item_id, sample);
+      }
+      console.log("delete cancelled...");
+    },
+  },
+  created() {
+    this.getSamples();
+  },
+  components: {
+    Vue3EasyDataTable,
+    ChemicalFormula,
+    Creators,
+  },
+};
+</script>
+
+<style scoped>
+.avatar {
+  border: 2px solid grey;
+  border-radius: 50%;
+}
+.avatar:hover {
+  border: 2px solid skyblue;
+}
+</style>
+
+<style>
+.customize-table th {
+  --easy-table-row-border: 2px solid #dee2e6;
+  border-top: 0.5px solid #dee2e6 !important;
+}
+
+.customize-table tr {
+  cursor: pointer;
+}
+
+.customize-table {
+  --easy-table-border: none;
+  --easy-table-row-border: 1px solid #dee2e6;
+  --easy-table-header-font-size: 1rem;
+  --easy-table-body-row-font-size: 1rem;
+  --easy-table-footer-font-size: 1rem;
+  --easy-table-message-font-size: 1rem;
+}
+</style>

--- a/webapp/src/components/FancySampleTable.vue
+++ b/webapp/src/components/FancySampleTable.vue
@@ -63,7 +63,6 @@ import ChemicalFormula from "@/components/ChemicalFormula";
 import Creators from "@/components/Creators";
 // eslint-disable-next-line no-unused-vars
 import { getSampleList, deleteSample } from "@/server_fetch_utils.js";
-import crypto from "crypto";
 import { GRAVATAR_STYLE, itemTypes } from "@/resources.js";
 
 export default {
@@ -80,7 +79,7 @@ export default {
         { text: "Sample name", value: "name", sortable: true },
         { text: "Formula", value: "chemform", sortable: true },
         { text: "Date", value: "date", sortable: true },
-        { text: "Creators", value: "creators" },
+        { text: "Creators", value: "creators", sortable: true },
         { text: "# of blocks", value: "nblocks", sortable: true },
       ],
       searchValue: "",
@@ -92,10 +91,6 @@ export default {
     },
   },
   methods: {
-    md5(value) {
-      // Returns the MD5 hash of the given string.
-      return crypto.createHash("md5").update(value).digest("hex");
-    },
     goToEditPage(row, event) {
       // don't actually go to editpage is this click is in the select column, because
       // that is easy to accidentally do. in future, could try to actuate the checkbox, too.

--- a/webapp/src/components/FancyStartingMaterialTable.vue
+++ b/webapp/src/components/FancyStartingMaterialTable.vue
@@ -1,0 +1,122 @@
+<template>
+  <div v-if="isFetchError" class="alert alert-danger">
+    <font-awesome-icon icon="exclamation-circle" />&nbsp;Inventory could not be retreived. Are you
+    logged in?
+  </div>
+  <div class="form-inline ml-auto col-3 mb-2">
+    <div class="form-group">
+      <label for="sample-table-search" class="sr-only">Search items</label>
+      <input
+        id="sample-table-search"
+        type="text"
+        class="form-control"
+        v-model="searchValue"
+        placeholder="search"
+      />
+    </div>
+  </div>
+
+  <Vue3EasyDataTable
+    :headers="headers"
+    :items="startingMaterials"
+    :search-value="searchValue"
+    table-class-name="customize-table"
+    header-class-name="customize-table-header"
+    buttons-pagination
+    @click-row="goToEditPage"
+  >
+    <template #item-item_id="item">
+      <FormattedItemName
+        :item_id="item.item_id"
+        :itemType="item?.type || 'starting_materials'"
+        enableModifiedClick
+      />
+    </template>
+    <template #item-chemform="item">
+      <ChemicalFormula :formula="item.chemform" />
+    </template>
+
+    <template #item-date_acquired="item">
+      {{ $filters.IsoDatetimeToDate(item.date_acquired) }}
+    </template>
+  </Vue3EasyDataTable>
+</template>
+
+<script>
+import Vue3EasyDataTable from "vue3-easy-data-table";
+import "vue3-easy-data-table/dist/style.css";
+
+import ChemicalFormula from "@/components/ChemicalFormula";
+import FormattedItemName from "@/components/FormattedItemName";
+import { getStartingMaterialList } from "@/server_fetch_utils.js";
+
+export default {
+  data() {
+    return {
+      isFetchError: false,
+      searchValue: "",
+      headers: [
+        { text: "ID", value: "item_id", sortable: true },
+        { text: "Name", value: "name", sortable: true },
+        { text: "Formula", value: "chemform", sortable: true },
+        { text: "Date", value: "date_acquired", sortable: true },
+        { text: "# of blocks", value: "nblocks", sortable: true },
+      ],
+    };
+  },
+  computed: {
+    startingMaterials() {
+      return this.$store.state.starting_material_list;
+    },
+  },
+  methods: {
+    goToEditPage(row, event) {
+      // don't actually go to editpage is this click is in the select column, because
+      // that is easy to accidentally do. in future, could try to actuate the checkbox, too.
+      if (event.target.querySelector(".easy-checkbox")) {
+        return null;
+      }
+      // if using a modifier key (ctr, meta, alt), open in new tab
+      // otherwise, go in this tab
+      if (event.ctrl || event.metaKey || event.altKey) {
+        window.open(`/edit/${row.item_id}`, "_blank");
+      } else {
+        this.$router.push(`/edit/${row.item_id}`);
+      }
+    },
+    getStartingMaterials() {
+      getStartingMaterialList().catch(() => {
+        this.isFetchError = true;
+      });
+    },
+  },
+  created() {
+    this.getStartingMaterials();
+  },
+  components: {
+    ChemicalFormula,
+    FormattedItemName,
+    Vue3EasyDataTable,
+  },
+};
+</script>
+
+<style scoped>
+.customize-table th {
+  --easy-table-row-border: 2px solid #dee2e6;
+  border-top: 0.5px solid #dee2e6 !important;
+}
+
+.customize-table tr {
+  cursor: pointer;
+}
+
+.customize-table {
+  --easy-table-border: none;
+  --easy-table-row-border: 1px solid #dee2e6;
+  --easy-table-header-font-size: 1rem;
+  --easy-table-body-row-font-size: 1rem;
+  --easy-table-footer-font-size: 1rem;
+  --easy-table-message-font-size: 1rem;
+}
+</style>

--- a/webapp/src/components/SampleTable.vue
+++ b/webapp/src/components/SampleTable.vue
@@ -88,7 +88,7 @@ export default {
     deleteSample(sample) {
       if (confirm(`Are you sure you want to delete sample "${sample.item_id}"?`)) {
         console.log("deleting...");
-        deleteSample(sample.item_id, sample);
+        deleteSample(sample.item_id);
       }
       console.log("delete cancelled...");
     },

--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -4,6 +4,7 @@ import { createRouter, createWebHistory } from "vue-router";
 import Samples from "../views/Samples.vue";
 import SamplesNext from "../views/SamplesNext.vue";
 import StartingMaterials from "../views/StartingMaterials.vue";
+import StartingMaterialsNext from "../views/StartingMaterialsNext.vue";
 import NotFound from "../views/NotFound.vue";
 import EditPage from "../views/EditPage.vue";
 import Test from "@/components/Test.vue";
@@ -36,6 +37,11 @@ const routes = [
     path: "/starting-materials",
     name: "starting-materials",
     component: StartingMaterials,
+  },
+  {
+    path: "/next/starting-materials",
+    name: "starting-materials-next",
+    component: StartingMaterialsNext,
   },
   {
     path: "/test/",

--- a/webapp/src/router/index.js
+++ b/webapp/src/router/index.js
@@ -2,6 +2,7 @@ import { createRouter, createWebHistory } from "vue-router";
 // import Home from '../views/Home.vue'
 // import Test from '../views/Test.vue'
 import Samples from "../views/Samples.vue";
+import SamplesNext from "../views/SamplesNext.vue";
 import StartingMaterials from "../views/StartingMaterials.vue";
 import NotFound from "../views/NotFound.vue";
 import EditPage from "../views/EditPage.vue";
@@ -25,6 +26,7 @@ const routes = [
     alias: "/",
     component: Samples,
   },
+  { path: "/next/samples", name: "samples-next", alias: "/next", component: SamplesNext },
   {
     path: "/edit/:id",
     name: "edit",

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -179,13 +179,13 @@ export function searchUsers(query, nresults = 100) {
   });
 }
 
-export function deleteSample(item_id, sample_summary) {
+export function deleteSample(item_id) {
   return fetch_post(`${API_URL}/delete-sample/`, {
     item_id: item_id,
   })
     .then(function (response_json) {
       console.log("delete successful" + response_json);
-      store.commit("deleteFromSampleList", sample_summary);
+      store.commit("deleteFromSampleList", item_id);
     })
     .catch((error) => alert("Sample delete failed for " + item_id + ": " + error));
 }

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -37,12 +37,12 @@ export default createStore({
       // sampleSummary is a json object summarizing the new sample
       state.sample_list.unshift(sampleSummary);
     },
-    deleteFromSampleList(state, sample_summary) {
-      const index = state.sample_list.indexOf(sample_summary);
+    deleteFromSampleList(state, item_id) {
+      const index = state.sample_list.map((e) => e.item_id).indexOf(item_id);
       if (index > -1) {
         state.sample_list.splice(index, 1);
       } else {
-        console.log("deleteFromSampleList couldn't find the object");
+        console.log(`deleteFromSampleList couldn't find the item with id ${item_id}`);
       }
     },
     createItemData(state, payload) {

--- a/webapp/src/views/Samples.vue
+++ b/webapp/src/views/Samples.vue
@@ -12,7 +12,7 @@
     </div>
     <div class="row">
       <div class="col-sm-12 mx-auto">
-        <SampleTable />
+        <FancySampleTable />
       </div>
     </div>
   </div>
@@ -22,7 +22,7 @@
 
 <script>
 import Navbar from "@/components/Navbar";
-import SampleTable from "@/components/SampleTable";
+import FancySampleTable from "@/components/FancySampleTable";
 import CreateSampleModal from "@/components/CreateSampleModal";
 import BatchCreateSampleModal from "@/components/BatchCreateSampleModal";
 
@@ -36,7 +36,7 @@ export default {
   },
   components: {
     Navbar,
-    SampleTable,
+    FancySampleTable,
     CreateSampleModal,
     BatchCreateSampleModal,
   },

--- a/webapp/src/views/SamplesNext.vue
+++ b/webapp/src/views/SamplesNext.vue
@@ -12,7 +12,7 @@
     </div>
     <div class="row">
       <div class="col-sm-12 mx-auto">
-        <SampleTable />
+        <FancySampleTable />
       </div>
     </div>
   </div>
@@ -22,7 +22,7 @@
 
 <script>
 import Navbar from "@/components/Navbar";
-import SampleTable from "@/components/SampleTable";
+import FancySampleTable from "@/components/FancySampleTable";
 import CreateSampleModal from "@/components/CreateSampleModal";
 import BatchCreateSampleModal from "@/components/BatchCreateSampleModal";
 
@@ -36,7 +36,7 @@ export default {
   },
   components: {
     Navbar,
-    SampleTable,
+    FancySampleTable,
     CreateSampleModal,
     BatchCreateSampleModal,
   },

--- a/webapp/src/views/StartingMaterialsNext.vue
+++ b/webapp/src/views/StartingMaterialsNext.vue
@@ -1,0 +1,22 @@
+<template>
+  <Navbar />
+  <div id="tableContainer" class="container">
+    <div class="row">
+      <div class="col-sm-10 mx-auto">
+        <FancyStartingMaterialTable />
+      </div>
+    </div>
+  </div>
+</template>
+
+<script>
+import Navbar from "@/components/Navbar";
+import FancyStartingMaterialTable from "@/components/FancyStartingMaterialTable";
+
+export default {
+  components: {
+    Navbar,
+    FancyStartingMaterialTable,
+  },
+};
+</script>

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -11966,7 +11966,14 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   resolved "https://registry.yarnpkg.com/vue-template-es2015-compiler/-/vue-template-es2015-compiler-1.9.1.tgz#1ee3bc9a16ecbf5118be334bb15f9c46f82f5825"
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
-vue@^3.2.4:
+vue3-easy-data-table@^1.5.34:
+  version "1.5.34"
+  resolved "https://registry.yarnpkg.com/vue3-easy-data-table/-/vue3-easy-data-table-1.5.34.tgz#2436e8429bd1fe05a1186dc51b3fee42bcd2328d"
+  integrity sha512-hLe0Jp+xyhB5uprkzWxTiq6K0+nZhcxwADLC48YK1Rf3wxNA5UuZsgs6uXNmOQ2xGQyAjymp5v7NrzEBcGNqTg==
+  dependencies:
+    vue "^3.2.45"
+
+vue@^3.2.4, vue@^3.2.45:
   version "3.2.47"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.47.tgz#3eb736cbc606fc87038dbba6a154707c8a34cff0"
   integrity sha512-60188y/9Dc9WVrAZeUVSDxRQOZ+z+y5nO2ts9jWXSTkMvayiWxCWOWtBQoYjLeccfXkiiPZWAHcV+WTPhkqJHQ==

--- a/webapp/yarn.lock
+++ b/webapp/yarn.lock
@@ -288,10 +288,15 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.16.4", "@babel/parser@^7.20.13", "@babel/parser@^7.20.7", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0":
+"@babel/parser@^7.1.0", "@babel/parser@^7.20.13", "@babel/parser@^7.20.7", "@babel/parser@^7.4.3", "@babel/parser@^7.7.0":
   version "7.20.15"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.20.15.tgz#eec9f36d8eaf0948bb88c87a46784b5ee9fd0c89"
   integrity sha512-DI4a1oZuf8wC+oAJA9RW6ga3Zbe8RZFt7kD9i4qAspz3I/yHet1VvC3DiSy/fsUvv5pvJuNPh0LPOdCcqinDPg==
+
+"@babel/parser@^7.16.4":
+  version "7.21.3"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.21.3.tgz#1d285d67a19162ff9daa358d4cb41d50c06220b3"
+  integrity sha512-lobG0d7aOfQRXh8AyklEAgZGvA4FShxo6xQbUrrT/cNBPUdIDojlokwJsQyCC/eKia7ifqM0yP+2DRZ4WKw2RQ==
 
 "@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression@^7.18.6":
   version "7.18.6"
@@ -11967,9 +11972,9 @@ vue-template-es2015-compiler@^1.6.0, vue-template-es2015-compiler@^1.9.0:
   integrity sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==
 
 vue3-easy-data-table@^1.5.34:
-  version "1.5.34"
-  resolved "https://registry.yarnpkg.com/vue3-easy-data-table/-/vue3-easy-data-table-1.5.34.tgz#2436e8429bd1fe05a1186dc51b3fee42bcd2328d"
-  integrity sha512-hLe0Jp+xyhB5uprkzWxTiq6K0+nZhcxwADLC48YK1Rf3wxNA5UuZsgs6uXNmOQ2xGQyAjymp5v7NrzEBcGNqTg==
+  version "1.5.39"
+  resolved "https://registry.yarnpkg.com/vue3-easy-data-table/-/vue3-easy-data-table-1.5.39.tgz#fb52e7badab94492f972641f632f48f18f7dd2fa"
+  integrity sha512-SLELNEvvOXWGzdf9s6gnhtBG18XOQLhj6TadRkmrq63C0/2J0y4R3SazDOg1dB3YB5Un9qvHootssDQanjs0ag==
   dependencies:
     vue "^3.2.45"
 


### PR DESCRIPTION
Adding in a proper (third party) data table component to add quality of life improvements like sorting, searching, and batch operations to the item tables in the UI.

- [x] Convert sample table to vue3-easy-data-table component
- [x] Convert starting material table to similar material
- [x] Make sorting work properly (note: sorting on creators doesn't seem to work atm)
- [x] Batch manage feature (delete, add to collection, etc.)
- [ ] format buttons correctly with Samples.vue
- [ ] Update tests
