### PR TITLE
Graph view updates: filter out deleted nodes, add cells and item-centred graphs

### DIFF
--- a/pydatalab/pydatalab/models/cells.py
+++ b/pydatalab/pydatalab/models/cells.py
@@ -24,13 +24,13 @@ class CellFormat(str, Enum):
 
 class InlineSubstance(BaseModel):
     name: str
-    formula: str
+    chemform: Optional[str]
 
 
 class CellComponent(Constituent):
     """A constituent of a sample."""
 
-    item: Union[EntryReference, InlineSubstance] = Field(...)
+    item: Union[InlineSubstance, EntryReference]
     """A reference to item (sample or starting material) entry for the constituent substance."""
 
 

--- a/pydatalab/pydatalab/models/cells.py
+++ b/pydatalab/pydatalab/models/cells.py
@@ -30,7 +30,7 @@ class InlineSubstance(BaseModel):
 class CellComponent(Constituent):
     """A constituent of a sample."""
 
-    item: Union[InlineSubstance, EntryReference]
+    item: Union[EntryReference, InlineSubstance]
     """A reference to item (sample or starting material) entry for the constituent substance."""
 
 

--- a/pydatalab/pydatalab/models/cells.py
+++ b/pydatalab/pydatalab/models/cells.py
@@ -33,6 +33,20 @@ class CellComponent(Constituent):
     item: Union[EntryReference, InlineSubstance]
     """A reference to item (sample or starting material) entry for the constituent substance."""
 
+    @validator("item", pre=True, always=True)
+    def coerce_reference(cls, v):
+        if isinstance(v, dict):
+            id = v.pop("item_id", None)
+            if id:
+                return EntryReference(item_id=id, **v)
+            else:
+                name = v.pop("name", "")
+                chemform = v.pop("chemform", None)
+                if not name:
+                    raise ValueError("Inline substance must have a name!")
+                return InlineSubstance(name=name, chemform=chemform)
+        return v
+
 
 class Cell(Item):
     """A model for representing electrochemical cells."""

--- a/pydatalab/pydatalab/routes/v0_1/graphs.py
+++ b/pydatalab/pydatalab/routes/v0_1/graphs.py
@@ -1,4 +1,4 @@
-from typing import Callable, Dict
+from typing import Callable, Dict, Optional
 
 from flask import jsonify
 
@@ -6,7 +6,7 @@ from pydatalab.mongo import flask_mongo
 from pydatalab.routes.utils import get_default_permissions
 
 
-def get_graph_cy_format(item_id: str = None):
+def get_graph_cy_format(item_id: Optional[str] = None):
 
     if item_id is None:
         all_documents = flask_mongo.db.items.find(
@@ -53,6 +53,7 @@ def get_graph_cy_format(item_id: str = None):
                     "id": document["item_id"],
                     "name": document["name"],
                     "type": document["type"],
+                    "special": document["item_id"] == item_id,
                 }
             }
         )

--- a/pydatalab/pydatalab/routes/v0_1/graphs.py
+++ b/pydatalab/pydatalab/routes/v0_1/graphs.py
@@ -35,7 +35,7 @@ def get_graph_cy_format():
 
         for relationship in document["relationships"]:
             # only considering child-parent relationships:
-            if relationship["relation"] != "parent":
+            if relationship["relation"] not in ("parent", "is_part_of"):
                 continue
 
             target = document["item_id"]
@@ -59,7 +59,7 @@ def get_graph_cy_format():
     nodes = [
         node
         for node in nodes
-        if node["data"]["type"] == "samples" or node["data"]["id"] in whitelist
+        if node["data"]["type"] in ("samples", "cells") or node["data"]["id"] in whitelist
     ]
 
     return (jsonify(status="success", nodes=nodes, edges=edges), 200)

--- a/pydatalab/pydatalab/routes/v0_1/graphs.py
+++ b/pydatalab/pydatalab/routes/v0_1/graphs.py
@@ -13,6 +13,9 @@ def get_graph_cy_format():
         projection={"item_id": 1, "name": 1, "type": 1, "relationships": 1},
     )
 
+    node_ids = {document["item_id"] for document in all_documents}
+    all_documents.rewind()
+
     nodes = []
     edges = []
     for document in all_documents:
@@ -37,6 +40,8 @@ def get_graph_cy_format():
 
             target = document["item_id"]
             source = relationship["item_id"]
+            if source not in node_ids:
+                continue
             edges.append(
                 {
                     "data": {
@@ -54,7 +59,7 @@ def get_graph_cy_format():
     nodes = [
         node
         for node in nodes
-        if ((node["data"]["type"] == "samples") or (node["data"]["id"] in whitelist))
+        if node["data"]["type"] == "samples" or node["data"]["id"] in whitelist
     ]
 
     return (jsonify(status="success", nodes=nodes, edges=edges), 200)

--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -349,7 +349,7 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
                 "date": data_model.date,
                 "name": data_model.name,
                 "creator_ids": data_model.creator_ids,
-                "creators": [json.loads(c.json()) for c in data_model.creators]
+                "creators": [json.loads(c.json(exclude_unset=True)) for c in data_model.creators]
                 if data_model.creators
                 else [],
                 "type": data_model.type,

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -358,6 +358,23 @@
       ],
       "type": "string"
     },
+    "InlineSubstance": {
+      "title": "InlineSubstance",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "chemform": {
+          "title": "Chemform",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
     "EntryReference": {
       "title": "EntryReference",
       "description": "A reference to a database entry by ID and type.\n\nCan include additional arbitarary metadata useful for\ninlining the item data.",
@@ -390,24 +407,6 @@
         "type"
       ]
     },
-    "InlineSubstance": {
-      "title": "InlineSubstance",
-      "type": "object",
-      "properties": {
-        "name": {
-          "title": "Name",
-          "type": "string"
-        },
-        "formula": {
-          "title": "Formula",
-          "type": "string"
-        }
-      },
-      "required": [
-        "name",
-        "formula"
-      ]
-    },
     "CellComponent": {
       "title": "CellComponent",
       "description": "A constituent of a sample.",
@@ -417,10 +416,10 @@
           "title": "Item",
           "anyOf": [
             {
-              "$ref": "#/definitions/EntryReference"
+              "$ref": "#/definitions/InlineSubstance"
             },
             {
-              "$ref": "#/definitions/InlineSubstance"
+              "$ref": "#/definitions/EntryReference"
             }
           ]
         },

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -358,23 +358,6 @@
       ],
       "type": "string"
     },
-    "InlineSubstance": {
-      "title": "InlineSubstance",
-      "type": "object",
-      "properties": {
-        "name": {
-          "title": "Name",
-          "type": "string"
-        },
-        "chemform": {
-          "title": "Chemform",
-          "type": "string"
-        }
-      },
-      "required": [
-        "name"
-      ]
-    },
     "EntryReference": {
       "title": "EntryReference",
       "description": "A reference to a database entry by ID and type.\n\nCan include additional arbitarary metadata useful for\ninlining the item data.",
@@ -407,6 +390,23 @@
         "type"
       ]
     },
+    "InlineSubstance": {
+      "title": "InlineSubstance",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "chemform": {
+          "title": "Chemform",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
     "CellComponent": {
       "title": "CellComponent",
       "description": "A constituent of a sample.",
@@ -416,10 +416,10 @@
           "title": "Item",
           "anyOf": [
             {
-              "$ref": "#/definitions/InlineSubstance"
+              "$ref": "#/definitions/EntryReference"
             },
             {
-              "$ref": "#/definitions/EntryReference"
+              "$ref": "#/definitions/InlineSubstance"
             }
           ]
         },

--- a/pydatalab/tests/conftest.py
+++ b/pydatalab/tests/conftest.py
@@ -31,7 +31,7 @@ def monkeypatch_session():
     m.undo()
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def real_mongo_client() -> Union[pymongo.MongoClient, None]:
     """Returns a connected MongoClient if available, otherwise `None`."""
     client = pymongo.MongoClient(
@@ -45,7 +45,7 @@ def real_mongo_client() -> Union[pymongo.MongoClient, None]:
     return client
 
 
-@pytest.fixture(scope="session")
+@pytest.fixture(scope="module")
 def client(real_mongo_client, monkeypatch_session):
     """Returns a test client for the API. If it exists,
     connects to a local MongoDB, otherwise uses the

--- a/pydatalab/tests/routers/test_graph.py
+++ b/pydatalab/tests/routers/test_graph.py
@@ -1,44 +1,48 @@
 import json
 
-from pydatalab.models import Sample
-from pydatalab.models.relationships import RelationshipType, TypedRelationship
+from pydatalab.models import Cell, Sample
+from pydatalab.models.samples import Constituent
 
 
-def test_new_sample_with_relationships(client):
+def test_simple_graph(client):
 
     parent = Sample(
         item_id="parent",
-        relationships=[
-            TypedRelationship(type="samples", relation=RelationshipType.PARENT, item_id="child_1"),
-            TypedRelationship(type="samples", relation=RelationshipType.PARENT, item_id="child_2"),
-            TypedRelationship(
-                type="samples", relation=RelationshipType.PARENT, item_id="missing_child"
-            ),
-        ],
-    ).json()
+    )
 
     child_1 = Sample(
         item_id="child_1",
-        relationships=[
-            TypedRelationship(type="samples", relation=RelationshipType.CHILD, item_id="parent"),
+        synthesis_constituents=[
+            Constituent(item={"type": "samples", "item_id": "parent"}, quantity=None),
         ],
-    ).json()
+    )
 
     child_2 = Sample(
         item_id="child_2",
-        relationships=[
-            TypedRelationship(type="samples", relation=RelationshipType.CHILD, item_id="parent"),
+        synthesis_constituents=[
+            Constituent(item={"type": "samples", "item_id": "parent"}, quantity=None),
         ],
-    ).json()
+    )
 
     missing_child = Sample(
         item_id="missing_child",
-        relationships=[
-            TypedRelationship(type="samples", relation=RelationshipType.CHILD, item_id="parent"),
+        synthesis_constituents=[
+            Constituent(item={"type": "samples", "item_id": "parent"}, quantity=None),
         ],
-    ).json()
+    )
 
-    new_samples = [json.loads(d) for d in [parent, child_1, child_2, missing_child]]
+    cell = Cell(
+        item_id="abcd-1-2-3",
+        positive_electrode=[{"item": parent, "quantity": 2}],
+        negative_electrode=[
+            {"item": {"name": "My secret cathode", "formula": "NaCoO2"}, "quantity": 3}
+        ],
+        characteristic_mass=1.2,
+        active_ion="Na+",
+        cell_format="swagelok",
+    )
+
+    new_samples = [json.loads(d.json()) for d in [parent, child_1, child_2, missing_child, cell]]
 
     response = client.post(
         "/new-samples/",
@@ -46,25 +50,27 @@ def test_new_sample_with_relationships(client):
     )
 
     assert response.status_code == 207
-    assert response.json["http_codes"] == [201, 201, 201, 201]
+    assert all(d == 201 for d in response.json["http_codes"])
 
-    graph = client.get("/item-graph/").json
+    graph = client.get("/item-graph").json
     assert {n["data"]["id"] for n in graph["nodes"]} == {
         "parent",
         "child_1",
         "child_2",
         "missing_child",
+        "abcd-1-2-3",
     }
-    assert len(graph["edges"]) == 3
+    assert len(graph["edges"]) == 4
 
     response = client.post("/delete-sample/", json={"item_id": "missing_child"})
     assert response
 
-    graph = client.get("/item-graph/").json
+    graph = client.get("/item-graph").json
     assert {n["data"]["id"] for n in graph["nodes"]} == {
         "parent",
         "child_1",
         "child_2",
+        "abcd-1-2-3",
     }
 
-    assert len(graph["edges"]) == 2
+    assert len(graph["edges"]) == 3

--- a/pydatalab/tests/routers/test_graph.py
+++ b/pydatalab/tests/routers/test_graph.py
@@ -74,3 +74,9 @@ def test_simple_graph(client):
     }
 
     assert len(graph["edges"]) == 3
+
+    graph = client.get("/item-graph/child_1").json
+    # These values are currently incorrect: really want to traverse the graph but need to
+    # resolve relationships first
+    assert len(graph["nodes"]) == 1
+    assert len(graph["edges"]) == 0

--- a/pydatalab/tests/routers/test_graph.py
+++ b/pydatalab/tests/routers/test_graph.py
@@ -1,0 +1,70 @@
+import json
+
+from pydatalab.models import Sample
+from pydatalab.models.relationships import RelationshipType, TypedRelationship
+
+
+def test_new_sample_with_relationships(client):
+
+    parent = Sample(
+        item_id="parent",
+        relationships=[
+            TypedRelationship(type="samples", relation=RelationshipType.PARENT, item_id="child_1"),
+            TypedRelationship(type="samples", relation=RelationshipType.PARENT, item_id="child_2"),
+            TypedRelationship(
+                type="samples", relation=RelationshipType.PARENT, item_id="missing_child"
+            ),
+        ],
+    ).json()
+
+    child_1 = Sample(
+        item_id="child_1",
+        relationships=[
+            TypedRelationship(type="samples", relation=RelationshipType.CHILD, item_id="parent"),
+        ],
+    ).json()
+
+    child_2 = Sample(
+        item_id="child_2",
+        relationships=[
+            TypedRelationship(type="samples", relation=RelationshipType.CHILD, item_id="parent"),
+        ],
+    ).json()
+
+    missing_child = Sample(
+        item_id="missing_child",
+        relationships=[
+            TypedRelationship(type="samples", relation=RelationshipType.CHILD, item_id="parent"),
+        ],
+    ).json()
+
+    new_samples = [json.loads(d) for d in [parent, child_1, child_2, missing_child]]
+
+    response = client.post(
+        "/new-samples/",
+        json={"new_sample_datas": new_samples},
+    )
+
+    assert response.status_code == 207
+    assert response.json["http_codes"] == [201, 201, 201, 201]
+
+    graph = client.get("/item-graph/").json
+    assert {n["data"]["id"] for n in graph["nodes"]} == {
+        "parent",
+        "child_1",
+        "child_2",
+        "missing_child",
+    }
+    assert len(graph["edges"]) == 3
+
+    response = client.post("/delete-sample/", json={"item_id": "missing_child"})
+    assert response
+
+    graph = client.get("/item-graph/").json
+    assert {n["data"]["id"] for n in graph["nodes"]} == {
+        "parent",
+        "child_1",
+        "child_2",
+    }
+
+    assert len(graph["edges"]) == 2

--- a/pydatalab/tests/routers/test_graph.py
+++ b/pydatalab/tests/routers/test_graph.py
@@ -35,7 +35,7 @@ def test_simple_graph(client):
         item_id="abcd-1-2-3",
         positive_electrode=[{"item": parent, "quantity": 2}],
         negative_electrode=[
-            {"item": {"name": "My secret cathode", "formula": "NaCoO2"}, "quantity": 3}
+            {"item": {"name": "My secret cathode", "chemform": "NaCoO2"}, "quantity": 3}
         ],
         characteristic_mass=1.2,
         active_ion="Na+",

--- a/pydatalab/tests/test_models.py
+++ b/pydatalab/tests/test_models.py
@@ -139,13 +139,13 @@ def test_cell_with_inlined_reference():
     from pydatalab.models.cells import Cell
     from pydatalab.models.samples import Sample
 
-    anode = Sample(item_id="test_anode", formula="C")
+    anode = Sample(item_id="test_anode", chemform="C")
 
     cell = Cell(
         item_id="abcd-1-2-3",
         positive_electrode=[{"item": anode, "quantity": 2}],
         negative_electrode=[
-            {"item": {"name": "My secret cathode", "formula": "NaCoO2"}, "quantity": 3}
+            {"item": {"name": "My secret cathode", "chemform": "NaCoO2"}, "quantity": 3}
         ],
         characteristic_mass=1.2,
         active_ion="Na+",
@@ -153,8 +153,63 @@ def test_cell_with_inlined_reference():
     )
 
     assert cell
-    assert len(cell.relationships == 1)
-    assert Cell(**json.loads(cell.json()))
+    assert len(cell.relationships) == 1
+
+    cell = Cell(**json.loads(cell.json()))
+    assert cell
+    assert len(cell.relationships) == 1
+
+    # test from raw json
+    cell_json = {
+        "item_id": "abcd-1-2-3",
+        "positive_electrode": [
+            {"item": {"type": "samples", "item_id": "test_anode", "chemform": "C"}, "quantity": 2}
+        ],
+        "negative_electrode": [
+            {"item": {"name": "My secret cathode", "chemform": "NaCoO2"}, "quantity": 3}
+        ],
+        "characteristic_mass": 1.2,
+        "active_ion": "Na+",
+        "cell_format": "swagelok",
+    }
+
+    cell = Cell(**cell_json)
+    assert cell
+    assert len(cell.relationships) == 1
+
+    cell_json_2 = {
+        "item_id": "abcd-1-2-3",
+        "positive_electrode": [
+            {"item": {"item_id": "", "name": "inline", "chemform": "C"}, "quantity": 2}
+        ],
+        "negative_electrode": [
+            {"item": {"name": "My secret cathode", "chemform": "NaCoO2"}, "quantity": 3}
+        ],
+        "characteristic_mass": 1.2,
+        "active_ion": "Na+",
+        "cell_format": "swagelok",
+    }
+
+    cell = Cell(**cell_json_2)
+    assert cell
+    assert len(cell.relationships) == 0
+
+    cell_json_3 = {
+        "item_id": "abcd-1-2-3",
+        "positive_electrode": [
+            {"item": {"type": "samples", "item_id": "real_item"}, "quantity": 2}
+        ],
+        "negative_electrode": [
+            {"item": {"name": "My secret cathode", "chemform": "NaCoO2"}, "quantity": 3}
+        ],
+        "characteristic_mass": 1.2,
+        "active_ion": "Na+",
+        "cell_format": "swagelok",
+    }
+
+    cell = Cell(**cell_json_3)
+    assert cell
+    assert len(cell.relationships) == 1
 
 
 def test_molar_mass():

--- a/pydatalab/tests/test_models.py
+++ b/pydatalab/tests/test_models.py
@@ -153,6 +153,7 @@ def test_cell_with_inlined_reference():
     )
 
     assert cell
+    assert len(cell.relationships == 1)
     assert Cell(**json.loads(cell.json()))
 
 

--- a/webapp/src/components/ItemGraph.vue
+++ b/webapp/src/components/ItemGraph.vue
@@ -66,7 +66,9 @@ export default {
       var cy = cytoscape({
         container: document.getElementById("cy"),
         elements: this.graphData,
-        userPanningEnabled: false,
+        userPanningEnabled: true,
+        wheelSensitivity: 0.2,
+        boxSelectionEnabled: false,
         style: [
           {
             selector: "node",
@@ -93,6 +95,11 @@ export default {
       // set colors of each of the nodes by type
       cy.nodes().each(function (element) {
         element.style("background-color", itemTypes[element.data("type")].navbarColor);
+      });
+
+      cy.nodes().each(function (element) {
+        element.style("border-width", element.data("special") == 1 ? 4 : 0);
+        element.style("border-color", "grey");
       });
 
       // tapdragover and tapdragout are mouseover and mouseout events

--- a/webapp/src/components/RelationshipVisualization.vue
+++ b/webapp/src/components/RelationshipVisualization.vue
@@ -88,7 +88,7 @@ export default {
     item_id: String,
   },
   async mounted() {
-    await getItemGraph();
+    await getItemGraph(this.item_id);
   },
   components: {
     // FormattedItemName

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -345,8 +345,12 @@ export async function addRemoteFileToSample(file_entry, item_id) {
     .catch((error) => `addRemoteFilesToSample unsuccessful. Error: ${error}`);
 }
 
-export async function getItemGraph() {
-  return fetch_get(`${API_URL}/item-graph/`)
+export async function getItemGraph(item_id = "") {
+  let url = `${API_URL}/item-graph`;
+  if (item_id != "") {
+    url = url + "/" + item_id;
+  }
+  return fetch_get(url)
     .then(function (response_json) {
       console.log("received graph");
       store.commit("setItemGraph", { nodes: response_json.nodes, edges: response_json.edges });

--- a/webapp/src/views/ItemGraphPage.vue
+++ b/webapp/src/views/ItemGraphPage.vue
@@ -1,8 +1,6 @@
 <template>
   <Navbar />
-  <div class="container">
-    <ItemGraph :graphData="graphData" style="height: 600px" />
-  </div>
+  <ItemGraph :graphData="graphData" />
 </template>
 
 <script>


### PR DESCRIPTION
- filter out deleted nodes in graph endpoint
- add relationships to cells and render cells in the graph
- re-enable user interaction with the graph (zoom/pan etc.)
- add graph endpoint specialization for graph centred on given item 