### PR TITLE
Allow inline references for samples, and other tweaks

### DIFF
--- a/pydatalab/pydatalab/models/cells.py
+++ b/pydatalab/pydatalab/models/cells.py
@@ -1,13 +1,17 @@
 from enum import Enum
-from typing import List, Optional, Union
+from typing import List, Optional
 
-from pydantic import BaseModel, Field, root_validator, validator
+from pydantic import Field, root_validator, validator
 
 from pydatalab.models.entries import EntryReference
 from pydatalab.models.items import Item
-from pydatalab.models.samples import Constituent
+from pydatalab.models.utils import Constituent
 
 # from pydatalab.logger import LOGGER
+
+
+class CellComponent(Constituent):
+    ...
 
 
 class CellFormat(str, Enum):
@@ -20,32 +24,6 @@ class CellFormat(str, Enum):
     swagelok = "swagelok"
     cylindrical = "cylindrical"
     other = "other"
-
-
-class InlineSubstance(BaseModel):
-    name: str
-    chemform: Optional[str]
-
-
-class CellComponent(Constituent):
-    """A constituent of a sample."""
-
-    item: Union[EntryReference, InlineSubstance]
-    """A reference to item (sample or starting material) entry for the constituent substance."""
-
-    @validator("item", pre=True, always=True)
-    def coerce_reference(cls, v):
-        if isinstance(v, dict):
-            id = v.pop("item_id", None)
-            if id:
-                return EntryReference(item_id=id, **v)
-            else:
-                name = v.pop("name", "")
-                chemform = v.pop("chemform", None)
-                if not name:
-                    raise ValueError("Inline substance must have a name!")
-                return InlineSubstance(name=name, chemform=chemform)
-        return v
 
 
 class Cell(Item):

--- a/pydatalab/pydatalab/models/entries.py
+++ b/pydatalab/pydatalab/models/entries.py
@@ -6,10 +6,9 @@ from pydantic import BaseModel, Field, root_validator
 from pydatalab.models.relationships import TypedRelationship
 from pydatalab.models.utils import (
     JSON_ENCODERS,
-    HumanReadableIdentifier,
+    EntryReference,
     IsoformatDateTime,
     PyObjectId,
-    Refcode,
 )
 
 
@@ -74,37 +73,3 @@ class Entry(BaseModel, abc.ABC):
         allow_population_by_field_name = True
         json_encoders = JSON_ENCODERS
         extra = "ignore"
-
-
-class EntryReference(BaseModel):
-    """A reference to a database entry by ID and type.
-
-    Can include additional arbitarary metadata useful for
-    inlining the item data.
-
-    """
-
-    type: str
-    immutable_id: Optional[PyObjectId]
-    item_id: Optional[HumanReadableIdentifier]
-    refcode: Optional[Refcode]
-
-    @root_validator
-    def check_id_fields(cls, values):
-        """Check that only one of the possible identifier fields is provided."""
-        id_fields = ("immutable_id", "item_id", "refcode")
-
-        # Temporarily remove refcodes from the list of fields to check
-        # until it is fully implemented
-        if values.get("refcode") is not None:
-            values["refcode"] = None
-        if all(values.get(f) is None for f in id_fields):
-            raise ValueError(f"Must provide at least one of {id_fields!r}")
-
-        if sum(1 for f in id_fields if values.get(f) is not None) > 1:
-            raise ValueError("Must provide only one of {id_fields!r}")
-
-        return values
-
-    class Config:
-        extra = "allow"

--- a/pydatalab/pydatalab/mongo.py
+++ b/pydatalab/pydatalab/mongo.py
@@ -18,8 +18,13 @@ flask_mongo = PyMongo()
 """This is the primary database interface used by the Flask app."""
 
 
-def insert_pydantic_model_fork_safe(model: BaseModel, collection: str) -> None:
-    get_database()[collection].insert_one(model.dict(by_alias=True))
+def insert_pydantic_model_fork_safe(model: BaseModel, collection: str) -> str:
+    """Inserts a Pydantic model into chosen collection, returning the inserted ID."""
+    return (
+        get_database()[collection]
+        .insert_one(model.dict(by_alias=True, exclude_none=True))
+        .inserted_id
+    )
 
 
 def _get_active_mongo_client(timeoutMS: int = 1000) -> pymongo.MongoClient:

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -500,6 +500,10 @@
           "title": "Type",
           "type": "string"
         },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
         "immutable_id": {
           "title": "Immutable Id",
           "type": "string"

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -444,6 +444,10 @@
           "title": "Type",
           "type": "string"
         },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
         "immutable_id": {
           "title": "Immutable Id",
           "type": "string"
@@ -467,13 +471,38 @@
         "type"
       ]
     },
+    "InlineSubstance": {
+      "title": "InlineSubstance",
+      "type": "object",
+      "properties": {
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "chemform": {
+          "title": "Chemform",
+          "type": "string"
+        }
+      },
+      "required": [
+        "name"
+      ]
+    },
     "Constituent": {
       "title": "Constituent",
       "description": "A constituent of a sample.",
       "type": "object",
       "properties": {
         "item": {
-          "$ref": "#/definitions/EntryReference"
+          "title": "Item",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EntryReference"
+            },
+            {
+              "$ref": "#/definitions/InlineSubstance"
+            }
+          ]
         },
         "quantity": {
           "title": "Quantity",

--- a/pydatalab/tests/test_models.py
+++ b/pydatalab/tests/test_models.py
@@ -16,6 +16,43 @@ from pydatalab.models.relationships import (
 from pydatalab.models.utils import HumanReadableIdentifier, Refcode
 
 
+def test_sample_with_inlined_reference():
+    from pydatalab.models.samples import Sample
+
+    a = Sample(item_id="test_anode", chemform="C")
+
+    b = Sample(
+        item_id="abcd-1-2-3",
+        synthesis_constituents=[
+            {"item": {"item_id": a.item_id, "type": "samples"}, "quantity": None}
+        ],
+    )
+
+    assert b
+    assert len(b.relationships) == 1
+
+    c = Sample(
+        item_id="c-123",
+        synthesis_constituents=[
+            {"item": {"item_id": a.item_id, "type": "samples"}, "quantity": None},
+            {"item": {"name": "inline"}, "quantity": None},
+        ],
+    )
+
+    assert c
+    assert len(c.relationships) == 1
+
+    d = Sample(
+        item_id="d-123",
+        synthesis_constituents=[
+            {"item": {"name": a.item_id}, "quantity": None},
+            {"item": {"name": "inline"}, "quantity": None},
+        ],
+    )
+    assert d
+    assert len(d.relationships) == 0
+
+
 @pytest.mark.parametrize("model", ITEM_MODELS.values())
 def test_generate_schemas(model):
     """Test that all item model schemas can be generated."""

--- a/webapp/cypress/e2e/batchSampleFeature.cy.js
+++ b/webapp/cypress/e2e/batchSampleFeature.cy.js
@@ -36,6 +36,20 @@ function getSubmitButton() {
   return cy.get("[data-testid=batch-modal-container]").contains("Submit");
 }
 
+function searchAndSelectItem(search_text, selector, delay = 100) {
+  // searches in the dropdown for the first real item with the given name, looking for a badge
+  // if click_plus, then also click the add row button before looking for the search bar
+  cy.get("#synthesis-information").within(() => {
+    cy.get("svg.add-row-button").click();
+  });
+  cy.get(selector).first().type(search_text);
+  cy.wait(delay).then(() => {
+    cy.get(".vs__dropdown-menu").within(() => {
+      cy.contains(".badge", search_text).click();
+    });
+  });
+}
+
 function deleteSample(sample_id, delay = 100) {
   cy.wait(delay).then(() => {
     cy.log("search for and delete: " + sample_id);
@@ -158,18 +172,6 @@ describe("Batch sample creation", () => {
   it("modifies some data in the second sample", () => {
     cy.findByText("baseB").click();
     cy.findByLabelText("Description").type("this is a description of baseB.");
-    cy.get("#synthesis-information .vs__search").first().type("component3");
-    cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component3").click();
-    });
-    cy.get("#synthesis-information tbody tr:nth-of-type(1) input").first().type("30");
-
-    cy.get("#synthesis-information .vs__search").first().type("component4");
-    cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component4").click();
-    });
-    cy.get("#synthesis-information tbody tr:nth-of-type(2) input").eq(0).type("100");
-
     cy.findByText("Add a block").click();
     cy.findByLabelText("Add a block").contains("Comment").click();
     cy.get(".datablock-content div").first().type("a comment is added here.");
@@ -179,6 +181,12 @@ describe("Batch sample creation", () => {
     cy.findByText("Add a block").click();
     cy.findByLabelText("Add a block").findByText("Comment").click();
     cy.get(".datablock-content").eq(1).type("a second comment is added here.");
+
+    searchAndSelectItem("component3", "#synthesis-information .vs__search");
+    cy.get("#synthesis-information tbody tr:nth-of-type(1) input").first().type("30");
+
+    searchAndSelectItem("component4", "#synthesis-information .vs__search");
+    cy.get("#synthesis-information tbody tr:nth-of-type(2) input").eq(0).type("100");
 
     cy.get(".fa-save").click();
     cy.findByText("Home").click();
@@ -190,19 +198,19 @@ describe("Batch sample creation", () => {
     getBatchAddCell(1, 2).type("a copied sample");
     getBatchAddCell(1, 4, ".vs__search").type("BaseA");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("baseA").click();
+      cy.contains(".badge", "baseA").click();
     });
 
     getBatchAddCell(2, 1).type("baseB_copy");
     getBatchAddCell(2, 4, ".vs__search").type("BaseB");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("baseB").click();
+      cy.contains(".badge", "baseB").click();
     });
 
     getBatchAddCell(3, 1).type("baseB_copy2");
     getBatchAddCell(3, 4, ".vs__search").type("BaseB");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("baseB").click();
+      cy.contains(".badge", "baseB").click();
     });
 
     getSubmitButton().click();
@@ -265,11 +273,11 @@ describe("Batch sample creation", () => {
     getBatchAddCell(1, 2).type("sample with two components");
     getBatchAddCell(1, 5, ".vs__search").type("component1");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component1").click();
+      cy.contains(".badge", "component1").click();
     });
     getBatchAddCell(1, 5, ".vs__search").type("component2");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component2").click();
+      cy.contains(".badge", "component2").click();
     });
 
     // sample with two components, copied from a sample with no components
@@ -279,15 +287,15 @@ describe("Batch sample creation", () => {
     );
     getBatchAddCell(2, 4, ".vs__search").type("baseA");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("baseA").click();
+      cy.contains(".badge", "baseA").click();
     });
     getBatchAddCell(2, 5, ".vs__search").type("component1");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component1").click();
+      cy.contains(".badge", "component1").click();
     });
     getBatchAddCell(2, 5, ".vs__search").type("component2");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component2").click();
+      cy.contains(".badge", "component2").click();
     });
 
     // sample with one components, copied from a sample with two components
@@ -297,11 +305,11 @@ describe("Batch sample creation", () => {
     );
     getBatchAddCell(3, 4, ".vs__search").type("baseB");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("baseB").click();
+      cy.contains(".badge", "baseB").click();
     });
     getBatchAddCell(3, 5, ".vs__search").type("component1");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component1").click();
+      cy.contains(".badge", "component1").click();
     });
 
     // sample with three components, copied from a sample with some of the same components
@@ -311,19 +319,19 @@ describe("Batch sample creation", () => {
     );
     getBatchAddCell(4, 4, ".vs__search").type("baseB");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("baseB").click();
+      cy.contains(".badge", "baseB").click();
     });
     getBatchAddCell(4, 5, ".vs__search").type("component2");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component2").click();
+      cy.contains(".badge", "component2").click();
     });
     getBatchAddCell(4, 5, ".vs__search").type("component3");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component3").click();
+      cy.contains(".badge", "component3").click();
     });
     getBatchAddCell(4, 5, ".vs__search").type("component4");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component4").click();
+      cy.contains(".badge", "component4").click();
     });
 
     getSubmitButton().click();
@@ -373,19 +381,19 @@ describe("Batch sample creation", () => {
     cy.get("#synthesis-information table").contains("component3");
     cy.get("#synthesis-information table").contains("component4");
 
-    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(3) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(2) input").should(
       "have.value",
       "30"
     );
-    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(4) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(3) input").should(
       "have.value",
       "g"
     );
-    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(3) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(2) input").should(
       "have.value",
       "100"
     );
-    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(4) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(3) input").should(
       "have.value",
       "g"
     );
@@ -406,27 +414,27 @@ describe("Batch sample creation", () => {
     cy.get("#synthesis-information table").contains("component3");
     cy.get("#synthesis-information table").contains("component4");
 
-    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(3) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(2) input").should(
       "have.value",
       "30"
     );
-    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(4) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(3) input").should(
       "have.value",
       "g"
     );
-    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(3) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(2) input").should(
       "have.value",
       "100"
     );
-    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(4) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(3) input").should(
       "have.value",
       "g"
     );
-    cy.get("#synthesis-information tbody tr:nth-of-type(3) td:nth-of-type(3) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(3) td:nth-of-type(2) input").should(
       "have.value",
       ""
     );
-    cy.get("#synthesis-information tbody tr:nth-of-type(3) td:nth-of-type(4) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(3) td:nth-of-type(3) input").should(
       "have.value",
       "g"
     );
@@ -499,7 +507,7 @@ describe("Batch sample creation", () => {
     // select copyFrom sample, check that it is applied correctly
     getBatchTemplateCell(4, ".vs__search").type("baseA");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("baseA").click();
+      cy.contains(".badge", "baseA").click();
     });
 
     getBatchAddCell(1, 4).contains("baseA");
@@ -509,7 +517,7 @@ describe("Batch sample creation", () => {
     // change the copyFrom sample, check that it is applied correctly
     getBatchTemplateCell(4, ".vs__search").type("baseB");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("baseB").click();
+      cy.contains(".badge", "baseB").click();
     });
 
     getBatchAddCell(1, 4).contains("baseB");
@@ -519,7 +527,7 @@ describe("Batch sample creation", () => {
     // add a component, check that it is applied correctly
     getBatchTemplateCell(5, ".vs__search").type("component1");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component1").click();
+      cy.contains(".badge", "component1").click();
     });
     getBatchAddCell(1, 5).contains("component1");
     getBatchAddCell(2, 5).contains("component1");
@@ -528,7 +536,7 @@ describe("Batch sample creation", () => {
     // add another component, check that it is applied correctly
     getBatchTemplateCell(5, ".vs__search").type("component2");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component2").click();
+      cy.contains(".badge", "component2").click();
     });
     getBatchAddCell(1, 5).contains("component1");
     getBatchAddCell(1, 5).contains("component2");
@@ -594,22 +602,22 @@ describe("Batch sample creation", () => {
 
     getBatchTemplateCell(4, ".vs__search").type("baseB");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("baseB").click();
+      cy.contains(".badge", "baseB").click();
     });
 
     getBatchTemplateCell(5, ".vs__search").type("component1");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component1").click();
+      cy.contains(".badge", "component1").click();
     });
 
     getBatchTemplateCell(5, ".vs__search").type("component3");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component3").click();
+      cy.contains(".badge", "component3").click();
     });
 
     getBatchTemplateCell(5, ".vs__search").type("component4");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component4").click();
+      cy.contains(".badge", "component4").click();
     });
 
     cy.findByLabelText("Number of rows:").clear().type(100);

--- a/webapp/cypress/e2e/editPage.cy.js
+++ b/webapp/cypress/e2e/editPage.cy.js
@@ -84,30 +84,32 @@ describe("Edit Page", () => {
 
   it("adds some synthesis information", () => {
     cy.findByText("editable_sample").click();
+    cy.get("svg.add-row-button").click();
     cy.get("#synthesis-information .vs__search").first().type("component1");
-    cy.get(".vs__dropdown-menu").contains("component1").click();
+    cy.get(".vs__dropdown-menu").contains(".badge", "component1").click();
     cy.get("#synthesis-information tbody > tr").should("have.length", 2);
     cy.findByText("Unsaved changes");
 
     cy.get("#synthesis-information").contains("component1");
     cy.get("#synthesis-information").contains("Na2O");
 
+    cy.get("svg.add-row-button").click();
     cy.get("#synthesis-information .vs__search").first().type("component2");
-    cy.get(".vs__dropdown-menu").contains("component2").click();
+    cy.get(".vs__dropdown-menu").contains(".badge", "component2").click();
 
     cy.get("#synthesis-information").contains("component2");
 
-    cy.get("#synthesis-information tr:nth-of-type(1) td:nth-of-type(3)").type(10);
-    cy.get("#synthesis-information tr:nth-of-type(1) td:nth-of-type(4)").clear().type("mL");
-    cy.get("#synthesis-information tr:nth-of-type(2) td:nth-of-type(3)").type(0.001);
-    cy.get("#synthesis-information tr:nth-of-type(2) td:nth-of-type(4)").clear().type("kg");
+    cy.get("#synthesis-information tr:nth-of-type(1) td:nth-of-type(2)").type(10);
+    cy.get("#synthesis-information tr:nth-of-type(1) td:nth-of-type(3)").clear().type("mL");
+    cy.get("#synthesis-information tr:nth-of-type(2) td:nth-of-type(2)").type(0.001);
+    cy.get("#synthesis-information tr:nth-of-type(2) td:nth-of-type(3)").clear().type("kg");
 
     // save the synthesis information and make sure unsaved changes goes away
     cy.contains("Unsaved changes");
     cy.wait(100).then(() => cy.get(".fa-save").click());
     cy.contains("Unsaved changes").should("not.exist");
 
-    cy.get("#synthesis-information tr:nth-of-type(2) td:nth-of-type(4) input")
+    cy.get("#synthesis-information tr:nth-of-type(2) td:nth-of-type(3) input")
       .clear()
       .type("pints");
     cy.contains("Unsaved changes");
@@ -116,19 +118,19 @@ describe("Edit Page", () => {
 
     cy.reload();
 
-    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(3) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(2) input").should(
       "have.value",
       10
     );
-    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(4) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(1) td:nth-of-type(3) input").should(
       "have.value",
       "mL"
     );
-    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(3) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(2) input").should(
       "have.value",
       0.001
     );
-    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(4) input").should(
+    cy.get("#synthesis-information tbody tr:nth-of-type(2) td:nth-of-type(3) input").should(
       "have.value",
       "pints"
     );
@@ -138,11 +140,11 @@ describe("Edit Page", () => {
     cy.findByText("editable_sample").click();
     cy.get("#synthesis-information tbody > tr:nth-of-type(1) .close").click();
     cy.get("#synthesis-information tbody > tr").should("have.length", 2);
-    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(3) input").should(
+    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(2) input").should(
       "have.value",
       0.001
     );
-    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(4) input").should(
+    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(3) input").should(
       "have.value",
       "pints"
     );
@@ -150,21 +152,23 @@ describe("Edit Page", () => {
     cy.get("#synthesis-information tbody > tr:nth-of-type(1) .close").click();
     cy.get("#synthesis-information tbody > tr").should("have.length", 1);
 
+    cy.get("svg.add-row-button").click();
     cy.get("#synthesis-information .vs__search").first().type("component2");
-    cy.get(".vs__dropdown-menu").contains("component2").click();
+    cy.get(".vs__dropdown-menu").contains(".badge", "component2").click();
     cy.get("#synthesis-information tbody > tr").should("have.length", 2);
     cy.get("#synthesis-information").contains("component2");
-    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(3) input").should(
+    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(2) input").should(
       "have.value",
       ""
     ); // should be reset, not a previous value
 
+    cy.get("svg.add-row-button").click();
     cy.get("#synthesis-information .vs__search").first().type("component1");
-    cy.get(".vs__dropdown-menu").contains("component1").click();
+    cy.get(".vs__dropdown-menu").contains(".badge", "component1").click();
     cy.get("#synthesis-information tbody > tr").should("have.length", 3);
     cy.get("#synthesis-information").contains("component1");
     cy.get("#synthesis-information").contains("Na2O");
-    cy.get("#synthesis-information tbody > tr:nth-of-type(2) td:nth-of-type(3) input").should(
+    cy.get("#synthesis-information tbody > tr:nth-of-type(2) td:nth-of-type(2) input").should(
       "have.value",
       ""
     ); // should be reset, not a previous value
@@ -172,36 +176,36 @@ describe("Edit Page", () => {
 
   it("tries to add a non-numeric value into quantity", () => {
     cy.findByText("editable_sample").click();
-    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(3) input").type(
+    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(2) input").type(
       "100.001"
     );
     cy.get(
-      "#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(3) input.red-border"
+      "#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(2) input.red-border"
     ).should("not.exist");
-    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(3) input")
+    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(2) input")
       .clear()
       .type("1");
     cy.get(
-      "#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(3) input.red-border"
+      "#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(2) input.red-border"
     ).should("not.exist");
-    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(3) input")
+    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(2) input")
       .clear()
       .type("word");
     cy.get(
-      "#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(3) input.red-border"
+      "#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(2) input.red-border"
     ).should("exist");
 
-    cy.get("#synthesis-information tbody > tr:nth-of-type(2) td:nth-of-type(3) input")
+    cy.get("#synthesis-information tbody > tr:nth-of-type(2) td:nth-of-type(2) input")
       .clear()
       .type("$");
     cy.get(
-      "#synthesis-information tbody > tr:nth-of-type(2) td:nth-of-type(3) input.red-border"
+      "#synthesis-information tbody > tr:nth-of-type(2) td:nth-of-type(2) input.red-border"
     ).should("exist");
 
-    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(3) input")
+    cy.get("#synthesis-information tbody > tr:nth-of-type(1) td:nth-of-type(2) input")
       .clear()
       .type("1");
-    cy.get("#synthesis-information tbody > tr:nth-of-type(2) td:nth-of-type(3) input")
+    cy.get("#synthesis-information tbody > tr:nth-of-type(2) td:nth-of-type(2) input")
       .clear()
       .type("1");
   });

--- a/webapp/cypress/e2e/sampleTablePage.cy.js
+++ b/webapp/cypress/e2e/sampleTablePage.cy.js
@@ -222,7 +222,7 @@ describe("Advanced sample creation features", () => {
     cy.findByLabelText("Sample ID:").type("testAcopy");
     cy.findByLabelText("(Optional) Copy from existing sample:").type("testA");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("testA").click();
+      cy.contains(".badge", "testA").click();
     });
     cy.findByDisplayValue("COPY OF the first test sample").clear().type("a copied sample");
     cy.contains("Submit").click();
@@ -248,15 +248,17 @@ describe("Advanced sample creation features", () => {
     cy.findByText("Comment").click();
 
     cy.get(".datablock-content div").first().type("a comment is added here.");
+    cy.get("svg.add-row-button").click();
     cy.get("#synthesis-information .vs__search").first().type("component3");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component3").click();
+      cy.contains(".badge", "component3").click();
     });
     cy.get("#synthesis-information tbody tr:nth-of-type(1) input").eq(0).type("30");
 
+    cy.get("svg.add-row-button").click();
     cy.get("#synthesis-information .vs__search").first().type("component4");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component4").click();
+      cy.contains(".badge", "component4").click();
     });
     cy.get("#synthesis-information tbody tr:nth-of-type(2) input").eq(0).type("100"); // eq(1) gets the second element that matches
 
@@ -273,7 +275,7 @@ describe("Advanced sample creation features", () => {
     cy.findByLabelText("Sample ID:").type("testBcopy");
     cy.findByLabelText("(Optional) Copy from existing sample:").type("testB");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("testB").click();
+      cy.contains(".badge", "testB").click();
     });
     cy.contains("Submit").click();
     verifySample("testBcopy", "COPY OF the second test sample");
@@ -299,16 +301,16 @@ describe("Advanced sample creation features", () => {
     cy.findByLabelText("Sample ID:").type("testBcopy_copy");
     cy.findByLabelText("(Optional) Copy from existing sample:").type("testBcopy");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("testBcopy").click();
+      cy.contains(".badge", "testBcopy").click();
     });
 
     cy.findByLabelText("(Optional) Start with constituents:").type("component2");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component2").click();
+      cy.contains(".badge", "component2").click();
     });
     cy.findByLabelText("(Optional) Start with constituents:").type("component3");
     cy.get(".vs__dropdown-menu").within(() => {
-      cy.findByText("component3").click();
+      cy.contains(".badge", "component3").click();
     });
 
     cy.contains("Submit").click();

--- a/webapp/src/components/CompactConstituentTable.vue
+++ b/webapp/src/components/CompactConstituentTable.vue
@@ -31,6 +31,7 @@
             :item_id="constituent.item.item_id"
             :itemType="constituent.item.type"
             :name="constituent.item.name"
+            :chemform="constituent.item.chemform || ''"
             enableClick
             enableModifiedClick
             @dblclick="turnOnRowSelect(index)"

--- a/webapp/src/components/CompactConstituentTable.vue
+++ b/webapp/src/components/CompactConstituentTable.vue
@@ -73,7 +73,7 @@
           <transition name="fade">
             <font-awesome-icon
               class="add-row-button"
-              v-if="!newSelectIsShown"
+              v-if="!addNewConstituentIsActive"
               :icon="['far', 'plus-square']"
             />
           </transition>

--- a/webapp/src/components/CompactConstituentTable.vue
+++ b/webapp/src/components/CompactConstituentTable.vue
@@ -44,10 +44,15 @@
             class="form-control form-control-sm quantity-input"
             :class="{ 'red-border': isNaN(constituent.quantity) }"
             v-model="constituent.quantity"
+            placeholder="quantity"
           />
         </td>
         <td>
-          <input class="form-control form-control-sm" v-model="constituent.unit" />
+          <input
+            class="form-control form-control-sm"
+            v-model="constituent.unit"
+            placeholder="unit"
+          />
         </td>
 
         <td>

--- a/webapp/src/components/FormattedItemName.vue
+++ b/webapp/src/components/FormattedItemName.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div v-if="item_id">
     <span
       class="badge badge-light mr-2"
       :class="{ clickable: enableClick || enableModifiedClick }"
@@ -13,6 +13,10 @@
     {{ shortenedName }}
     <span v-if="chemform && chemform != ' '"> [ <ChemicalFormula :formula="chemform" /> ] </span>
   </div>
+  <div v-else>
+    <font-awesome-icon v-if="selecting" :icon="['far', 'plus-square']" />
+    {{ shortenedName }}
+  </div>
 </template>
 
 <script>
@@ -23,6 +27,10 @@ export default {
   props: {
     item_id: String,
     itemType: String,
+    selecting: {
+      type: Boolean,
+      default: false,
+    },
     name: String,
     chemform: String,
     enableClick: {

--- a/webapp/src/components/ItemSelect.vue
+++ b/webapp/src/components/ItemSelect.vue
@@ -19,6 +19,7 @@
         :item_id="item_id"
         :itemType="type"
         :name="name"
+        :selecting="true"
         :chemform="chemform"
         enableModifiedClick
         :maxLength="formattedItemNameMaxLength"
@@ -28,6 +29,7 @@
       <FormattedItemName
         :item_id="item_id"
         :itemType="type"
+        :selecting="true"
         :name="name"
         enableModifiedClick
         :maxLength="formattedItemNameMaxLength"

--- a/webapp/src/components/SynthesisInformation.vue
+++ b/webapp/src/components/SynthesisInformation.vue
@@ -1,76 +1,11 @@
 <template>
   <div id="synthesis-information">
     <label class="mr-2 pb-2">Synthesis Information</label>
-    <table class="table mb-2">
-      <thead>
-        <tr class="subheading">
-          <th style="width: calc(60% - 2rem)">Component</th>
-          <th style="width: 21%">Formula</th>
-          <th style="width: 12%">Amount</th>
-          <th style="width: 7%">Unit</th>
-          <th style="width: 1rem"></th>
-        </tr>
-      </thead>
-      <tbody class="borderless">
-        <tr v-for="(constituent, index) in constituents" :key="index">
-          <td class="first-column">
-            <transition name="fade">
-              <font-awesome-icon
-                v-if="!selectShown[index]"
-                :icon="['fas', 'search']"
-                class="swap-constituent-icon"
-                @click="turnOnRowSelect(index)"
-              />
-            </transition>
-            <ItemSelect
-              class="select-in-row"
-              v-if="selectShown[index]"
-              :ref="`select${index}`"
-              v-model="selectedChangedConstituent"
-              :clearable="false"
-              @option:selected="swapConstituent($event, index)"
-              @search:blur="selectShown[index] = false"
-            />
-            <FormattedItemName
-              v-else
-              :item_id="constituent.item.item_id"
-              :itemType="constituent.item.type"
-              :name="constituent.item.name"
-              enableClick
-              enableModifiedClick
-              @dblclick="turnOnRowSelect(index)"
-            />
-          </td>
-          <td>
-            <ChemicalFormula :formula="constituent.item?.chemform" />
-          </td>
-          <td>
-            <input
-              class="form-control quantity-input"
-              :class="{ 'red-border': isNaN(constituent.quantity) }"
-              v-model="constituent.quantity"
-            />
-          </td>
-          <td>
-            <input class="form-control" v-model="constituent.unit" />
-          </td>
-
-          <td>
-            <button
-              type="button"
-              class="close"
-              @click.stop="removeConstituent(index)"
-              aria-label="delete"
-            >
-              <span aria-hidden="true">&times;</span>
-            </button>
-          </td>
-        </tr>
-        <tr>
-          <ItemSelect v-model="selectedNewConstituent" @option:selected="addConstituent" />
-        </tr>
-      </tbody>
-    </table>
+    <div class="card component-card">
+      <div class="card-body pt-2 pb-0 mb-0 pl-5">
+        <CompactConstituentTable id="synthesis-table" v-model="constituents" />
+      </div>
+    </div>
     <span id="synthesis-procedure-label" class="subheading ml-2">Procedure</span>
     <TinyMceInline
       aria-labelledby="synthesis-procedure-label"
@@ -81,18 +16,13 @@
 
 <script>
 import TinyMceInline from "@/components/TinyMceInline";
-import ChemicalFormula from "@/components/ChemicalFormula.vue";
 import { createComputedSetterForItemField } from "@/field_utils.js";
-
-import ItemSelect from "@/components/ItemSelect.vue";
-import FormattedItemName from "@/components/FormattedItemName.vue";
+import CompactConstituentTable from "@/components/CompactConstituentTable.vue";
 
 export default {
   components: {
     TinyMceInline,
-    ChemicalFormula,
-    ItemSelect,
-    FormattedItemName,
+    CompactConstituentTable,
   },
   data() {
     return {


### PR DESCRIPTION
This PR allows samples to have inlined synthesis consituents, determined by name only. These inline references do not populate the relationships field.

This PR refactors the cell component and constituents to use the same models (with a new alias in case we want to extend one), and uses the same Vue component for the constituents table between samples and cells.

To-do/discuss:

- [ ] Should you be able to promote inline references to fully-fledged samples/starting materials?
