### PR TITLE
Remove constraints on 'other' cell format requiring a description

### DIFF
--- a/pydatalab/pydatalab/models/cells.py
+++ b/pydatalab/pydatalab/models/cells.py
@@ -83,16 +83,6 @@ class Cell(Item):
 
     active_ion_charge: float = Field(1)
 
-    @validator("cell_format", "cell_format_description")
-    def check_descriptions_for_ambiguous_formats(cls, v, values):
-        if (
-            values.get("cell_format") == CellFormat.other
-            and values.get("cell_format_description") is None
-        ):
-            raise ValueError("cell_format_description must be set if cell_format is 'other'")
-
-        return v
-
     @validator("characteristic_molar_mass", always=True, pre=True)
     def set_molar_mass(cls, v, values):
         from periodictable import formula


### PR DESCRIPTION
As reported by @Gesaph, the UI was not dealing with this constraint well, and its probably superfluous anyway, so I have removed it.