### PR TITLE
Add sample modal scroll

### DIFF
--- a/webapp/src/components/BatchCreateSampleModal.vue
+++ b/webapp/src/components/BatchCreateSampleModal.vue
@@ -548,18 +548,18 @@ export default {
   font-weight: 600;
 }
 
-.modal-enclosure >>> .modal-header {
+.modal-enclosure :deep(.modal-header) {
   padding: 0.5rem 1rem;
 }
 
-.modal-enclosure >>> .modal-dialog {
+.modal-enclosure :deep(.modal-dialog) {
   max-width: 95vw;
   min-height: 90vh;
   margin-top: 2.5vh;
   margin-bottom: 2.5vh;
 }
 
-.modal-enclosure >>> .modal-content {
+.modal-enclosure :deep(.modal-content) {
   height: 90vh;
   overflow: scroll;
   scroll-behavior: smooth;

--- a/webapp/src/components/CreateSampleModal.vue
+++ b/webapp/src/components/CreateSampleModal.vue
@@ -1,5 +1,5 @@
 <template>
-  <form @submit.prevent="submitForm">
+  <form @submit.prevent="submitForm" class="modal-enclosure">
     <Modal
       :modelValue="modelValue"
       @update:modelValue="$emit('update:modelValue', $event)"
@@ -201,5 +201,11 @@ export default {
 :deep(.form-error a) {
   color: #820000;
   font-weight: 600;
+}
+
+.modal-enclosure :deep(.modal-content) {
+  max-height: 90vh;
+  overflow: auto;
+  scroll-behavior: smooth;
 }
 </style>

--- a/webapp/src/components/FileSelectModal.vue
+++ b/webapp/src/components/FileSelectModal.vue
@@ -131,18 +131,18 @@ export default {
 </script>
 
 <style scoped>
-.modal-enclosure >>> .modal-header {
+.modal-enclosure :deep(.modal-header) {
   padding: 0.5rem 1rem;
 }
 
-.modal-enclosure >>> .modal-dialog {
+.modal-enclosure :deep(.modal-dialog) {
   max-width: 95%;
   min-height: 95vh;
   margin-top: 2.5vh;
   margin-bottom: 2.5vh;
 }
 
-.modal-enclosure >>> .modal-content {
+.modal-enclosure :deep(.modal-content) {
   height: 95vh;
   /*overflow: scroll;*/
 }


### PR DESCRIPTION
Adds `scroll:auto` to the sample creation modal so that it will scroll if on a small screen. closes #332

Also updates the vue deep css selectors from the old syntax (`>>>`) to the modern (`:deep`) syntax.
