### PR TITLE
Load blocks asynchronously

### DIFF
--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -638,7 +638,7 @@ def save_item():
             400,
         )
 
-    return jsonify(status="success"), 200
+    return jsonify(status="success", last_modified=updated_data["last_modified"]), 200
 
 
 save_item.methods = ("POST",)  # type: ignore

--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -447,7 +447,9 @@ def delete_sample():
 delete_sample.methods = ("POST",)  # type: ignore
 
 
-def get_item_data(item_id, load_blocks=True):
+def get_item_data(item_id, load_blocks=False):
+    # load_blocks = request.args.get("load_blocks") or load_blocks
+
     # retrieve the entry from the database:
     cursor = flask_mongo.db.items.aggregate(
         [

--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -447,8 +447,16 @@ def delete_sample():
 delete_sample.methods = ("POST",)  # type: ignore
 
 
-def get_item_data(item_id, load_blocks=False):
-    # load_blocks = request.args.get("load_blocks") or load_blocks
+def get_item_data(item_id, load_blocks: bool = False):
+    """Generates a JSON response for the item with the given `item_id`,
+    additionally resolving relationships to files and other items.
+
+    Parameters:
+       load_blocks: Whether to regenerate any data blocks associated with this
+           sample (i.e., create the Python object corresponding to the block and
+           call its render function).
+
+    """
 
     # retrieve the entry from the database:
     cursor = flask_mongo.db.items.aggregate(

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -144,8 +144,6 @@ export default {
         this.contentMaxHeight = "none";
       }
     });
-
-    this.$store.commit("setBlockNotUpdating", this.block_id);
   },
   components: {
     TinyMceInline,

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -92,7 +92,7 @@ export default {
       // to save so that the store is updated before sending data to the server
       tinymce.editors.forEach((editor) => {
         // check if editor is a child of this datablock
-        if (editor.bodyElement.closest(`#${this.block_id}`)) {
+        if (editor.bodyElement.closest(`#${this.block_id}`) && editor.isDirty()) {
           editor.save();
         }
       });

--- a/webapp/src/field_utils.js
+++ b/webapp/src/field_utils.js
@@ -34,7 +34,7 @@ export function createComputedSetterForItemField(item_field) {
       console.log(value);
       store.commit("updateItemData", {
         item_id: this.item_id,
-        block_data: { [item_field]: value ? value : null },
+        item_data: { [item_field]: value ? value : null },
       });
     },
   };

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -258,6 +258,7 @@ export function addABlock(item_id, block_type, index = null) {
 export function saveItem(item_id) {
   console.log("saveItem Called!");
   var item_data = store.state.all_item_data[item_id];
+  store.commit("setItemSaved", { item_id: item_id, isSaved: false });
   fetch_post(`${API_URL}/save-item/`, {
     item_id: item_id,
     data: item_data,
@@ -266,6 +267,10 @@ export function saveItem(item_id) {
       if (response_json.status === "success") {
         // this should always be true if you've gotten this far...
         console.log("Save successful!");
+        store.commit("updateItemData", {
+          item_id: item_id,
+          item_data: { last_modified: response_json.last_modified },
+        });
         store.commit("setItemSaved", { item_id: item_id, isSaved: true });
         store.state.all_item_data[item_id].display_order.forEach((block_id) => {
           store.commit("setBlockSaved", { block_id: block_id, isSaved: true });

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -113,8 +113,8 @@ export default createStore({
     },
     updateItemData(state, payload) {
       //requires the following fields in payload:
-      // item_id, block_data
-      Object.assign(state.all_item_data[payload.item_id], payload.block_data);
+      // item_id, item_data
+      Object.assign(state.all_item_data[payload.item_id], payload.item_data);
       state.saved_status_items[payload.item_id] = false;
     },
     setItemSaved(state, payload) {

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -99,7 +99,7 @@ import TableOfContents from "@/components/TableOfContents";
 import FileList from "@/components/FileList";
 import Modal from "@/components/Modal";
 import FileSelectModal from "@/components/FileSelectModal";
-import { getItemData, addABlock, saveItem } from "@/server_fetch_utils";
+import { getItemData, addABlock, saveItem, updateBlockFromServer } from "@/server_fetch_utils";
 
 import setupUppy from "@/file_upload.js";
 
@@ -169,9 +169,16 @@ export default {
       tinymce.editors.forEach((editor) => editor.save());
       saveItem(this.item_id);
     },
-    async getSampleData() {
-      await getItemData(this.item_id);
-      this.itemDataLoaded = true;
+    getSampleData() {
+      getItemData(this.item_id).then(() => {
+        this.itemDataLoaded = true;
+
+        // update each block asynchronously
+        this.item_data.display_order.forEach((block_id) => {
+          console.log(`calling update on block ${block_id}`);
+          updateBlockFromServer(this.item_id, block_id, this.item_data.blocks_obj[block_id]);
+        });
+      });
     },
     leavePageWarningListener(event) {
       event.preventDefault;

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -166,7 +166,9 @@ export default {
     saveSample() {
       // trigger the mce save so that they update the store with their content
       console.log("save sample clicked!");
-      tinymce.editors.forEach((editor) => editor.save());
+      tinymce.editors.forEach((editor) => {
+        editor.isDirty() && editor.save();
+      });
       saveItem(this.item_id);
     },
     getSampleData() {


### PR DESCRIPTION
This PR should dramatically help how responsive the site feels, by first loading the page without passing the blocks through DataBlock objects (potentially triggering plotting, etc.) and _then_ asynchronously updating the blocks by calling `updateBlockFromServer` on each individual block. This means the page should load quickly with slower plots, etc. potentially coming in later.