### PR TITLE
Add `collections` type to API

### DIFF
--- a/pydatalab/pydatalab/main.py
+++ b/pydatalab/pydatalab/main.py
@@ -210,13 +210,14 @@ def create_app(config_override: Dict[str, Any] = None) -> Flask:
 def register_endpoints(app: Flask):
     """Loops through the implemented endpoints, blueprints and error handlers adds them to the app."""
     from pydatalab.errors import ERROR_HANDLERS
-    from pydatalab.routes import ENDPOINTS, __api_version__, auth
+    from pydatalab.routes import BLUEPRINTS, ENDPOINTS, __api_version__, auth
 
     OAUTH_BLUEPRINTS = auth.OAUTH_BLUEPRINTS
 
+    major, minor, patch = __api_version__.split(".")
+    versions = ["", f"/v{major}", f"/v{major}.{minor}", f"/v{major}.{minor}.{patch}"]
+
     for rule, func in ENDPOINTS.items():
-        major, minor, patch = __api_version__.split(".")
-        versions = ["", f"/v{major}", f"/v{major}.{minor}", f"/v{major}.{minor}.{patch}"]
         for ver in versions:
             app.add_url_rule(
                 f"{ver}{rule}",
@@ -224,8 +225,12 @@ def register_endpoints(app: Flask):
                 logged_route(func),
             )
 
-    for bp in OAUTH_BLUEPRINTS:
-        app.register_blueprint(OAUTH_BLUEPRINTS[bp], url_prefix="/login")
+    for bp in BLUEPRINTS:
+        for ver in versions:
+            app.register_blueprint(bp, url_prefix=f"{ver}", name=f"{ver}/{bp.name}")
+
+    for bp in OAUTH_BLUEPRINTS:  # type: ignore
+        app.register_blueprint(OAUTH_BLUEPRINTS[bp], url_prefix="/login")  # type: ignore
 
     for exception_type, handler in ERROR_HANDLERS:
         app.register_error_handler(exception_type, handler)

--- a/pydatalab/pydatalab/models/__init__.py
+++ b/pydatalab/pydatalab/models/__init__.py
@@ -3,6 +3,7 @@ from typing import Dict, Type
 from pydantic import BaseModel
 
 from pydatalab.models.cells import Cell
+from pydatalab.models.collections import Collection
 from pydatalab.models.files import File
 from pydatalab.models.people import Person
 from pydatalab.models.samples import Sample
@@ -14,4 +15,4 @@ ITEM_MODELS: Dict[str, Type[BaseModel]] = {
     "cells": Cell,
 }
 
-__all__ = ("File", "Sample", "StartingMaterial", "Person", "ITEM_MODELS")
+__all__ = ("File", "Sample", "StartingMaterial", "Person", "Cell", "Collection", "ITEM_MODELS")

--- a/pydatalab/pydatalab/models/collections.py
+++ b/pydatalab/pydatalab/models/collections.py
@@ -1,0 +1,24 @@
+from typing import Optional
+
+from pydantic import Field
+
+from pydatalab.models.entries import Entry
+from pydatalab.models.traits import HasBlocks, HasOwner
+from pydatalab.models.utils import HumanReadableIdentifier
+
+
+class Collection(Entry, HasOwner, HasBlocks):
+
+    type: str = Field("collections", const="collections", pattern="^collections$")
+
+    collection_id: HumanReadableIdentifier
+    """A short human-readable/usable name for the collection."""
+
+    title: Optional[str]
+    """A descriptive title for the collection."""
+
+    description: Optional[str]
+    """A description of the collection, either in plain-text or a markup language."""
+
+    num_items: Optional[int] = Field(None)
+    """Inlined number of items associated with this collection."""

--- a/pydatalab/pydatalab/models/entries.py
+++ b/pydatalab/pydatalab/models/entries.py
@@ -1,5 +1,5 @@
 import abc
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from pydantic import BaseModel, Field, root_validator
 
@@ -33,12 +33,6 @@ class Entry(BaseModel, abc.ABC):
 
     relationships: Optional[List[TypedRelationship]] = None
     """A list of related entries and their types."""
-
-    revision: int = 1
-    """The revision number of the entry."""
-
-    revisions: Optional[Dict[int, Any]] = None
-    """An optional mapping from old revision numbers to the model state at that revision."""
 
     @root_validator(pre=True)
     def check_id_names(cls, values):

--- a/pydatalab/pydatalab/models/items.py
+++ b/pydatalab/pydatalab/models/items.py
@@ -1,11 +1,16 @@
 import abc
-from typing import Any, Dict, List, Optional
+from typing import List, Optional
 
 from pydantic import Field, validator
 
 from pydatalab.models.entries import Entry
 from pydatalab.models.files import File
-from pydatalab.models.people import Person
+from pydatalab.models.traits import (
+    HasBlocks,
+    HasOwner,
+    HasRevisionControl,
+    IsCollectable,
+)
 from pydatalab.models.utils import (
     HumanReadableIdentifier,
     IsoformatDateTime,
@@ -14,7 +19,7 @@ from pydatalab.models.utils import (
 )
 
 
-class Item(Entry, abc.ABC):
+class Item(Entry, HasOwner, HasRevisionControl, IsCollectable, HasBlocks, abc.ABC):
     """The generic model for data types that will be exposed with their own named endpoints."""
 
     refcode: Refcode = None  # type: ignore
@@ -25,12 +30,6 @@ class Item(Entry, abc.ABC):
     item_id: HumanReadableIdentifier
     """A locally unique, human-readable identifier for the entry. This ID is mutable."""
 
-    creator_ids: List[PyObjectId] = Field([])
-    """The database IDs of the user(s) who created the item."""
-
-    creators: Optional[List[Person]] = Field(None)
-    """Inlined info for the people associated with this item."""
-
     description: Optional[str]
     """A description of the item, either in plain-text or a markup language."""
 
@@ -39,12 +38,6 @@ class Item(Entry, abc.ABC):
 
     name: Optional[str]
     """An optional human-readable/usable name for the entry."""
-
-    blocks_obj: Dict[str, Any] = Field({})
-    """A mapping from block ID to block data."""
-
-    display_order: List[str] = Field([])
-    """The order in which to display block data in the UI."""
 
     files: Optional[List[File]]
     """Any files attached to this sample."""

--- a/pydatalab/pydatalab/models/relationships.py
+++ b/pydatalab/pydatalab/models/relationships.py
@@ -39,8 +39,9 @@ class TypedRelationship(BaseModel):
         description="A description of the relationship.",
     )
 
-    relation: RelationshipType = Field(
-        description="The type of relationship between the two items. If the type is 'other', then a human-readable description should be provided."
+    relation: Optional[RelationshipType] = Field(
+        None,
+        description="The type of relationship between the two items. If the type is 'other', then a human-readable description should be provided.",
     )
 
     type: KnownType = Field(description="The type of the related resource.")

--- a/pydatalab/pydatalab/models/traits.py
+++ b/pydatalab/pydatalab/models/traits.py
@@ -1,0 +1,76 @@
+from typing import Any, Dict, List, Optional
+
+from pydantic import BaseModel, Field, root_validator
+
+from pydatalab.models.people import Person
+from pydatalab.models.utils import PyObjectId
+
+
+class HasOwner(BaseModel):
+
+    creator_ids: List[PyObjectId] = Field([])
+    """The database IDs of the user(s) who created the item."""
+
+    creators: Optional[List[Person]] = Field(None)
+    """Inlined info for the people associated with this item."""
+
+
+class HasRevisionControl(BaseModel):
+
+    revision: int = 1
+    """The revision number of the entry."""
+
+    revisions: Optional[Dict[int, Any]] = None
+    """An optional mapping from old revision numbers to the model state at that revision."""
+
+
+class HasBlocks(BaseModel):
+
+    blocks_obj: Dict[str, Any] = Field({})
+    """A mapping from block ID to block data."""
+
+    display_order: List[str] = Field([])
+    """The order in which to display block data in the UI."""
+
+
+class IsCollectable(BaseModel):
+    """Trait mixin for models that can be
+    added to collections.
+    """
+
+    from pydatalab.models.collections import Collection
+
+    collections: List[Collection] = Field([])
+    """Inlined info for the collections associated with this item."""
+
+    @root_validator
+    def add_missing_collection_relationships(cls, values):
+        from pydatalab.models.relationships import TypedRelationship
+
+        if values.get("collections") is not None:
+
+            existing_parent_relationship_ids = set()
+            collections_set = set()
+            if values.get("relationships") is not None:
+                existing_parent_relationship_ids = set(
+                    relationship.immutable_id
+                    for relationship in values["relationships"]
+                    if relationship.type == "collections"
+                )
+            else:
+                values["relationships"] = []
+
+            for collection in values.get("collections", []):
+                if collection.immutable_id not in existing_parent_relationship_ids:
+                    relationship = TypedRelationship(
+                        relation=None,
+                        immutable_id=collection.immutable_id,
+                        type="collections",
+                        description="Is a member of",
+                    )
+                    values["relationships"].append(relationship)
+
+                # Accumulate all constituent IDs in a set to filter those that have been deleted
+                collections_set.add(collection.immutable_id)
+
+        return values

--- a/pydatalab/pydatalab/models/utils.py
+++ b/pydatalab/pydatalab/models/utils.py
@@ -33,6 +33,7 @@ class KnownType(str, Enum):
     BLOCKS = "blocks"
     FILES = "files"
     PEOPLE = "people"
+    COLLECTIONS = "collections"
 
 
 IDENTIFIER_REGEX = r"^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$"

--- a/pydatalab/pydatalab/mongo.py
+++ b/pydatalab/pydatalab/mongo.py
@@ -94,6 +94,7 @@ def create_default_indices(
         A list of messages returned by each `create_index` call.
 
     """
+    from pydatalab.logger import LOGGER
     from pydatalab.models import ITEM_MODELS
 
     if client is None:
@@ -132,6 +133,12 @@ def create_default_indices(
         weights={"refcode": 3, "item_id": 3, "name": 3, "chemform": 3},
     )
 
+    ret += create_or_recreate_text_index(
+        db.collections,
+        ["collection_id", "title", "description"],
+        weights={"collection_id": 3, "title": 3, "description": 3},
+    )
+
     ret += db.items.create_index("type", name="item type", background=background)
     ret += db.items.create_index(
         "item_id", unique=True, name="unique item ID", background=background
@@ -158,7 +165,7 @@ def create_default_indices(
             name="user identities full-text search",
             background=background,
         )
-    except Exception:
-        pass
+    except Exception as exc:
+        LOGGER.warning("Failed to create text index: %s", exc)
 
     return ret

--- a/pydatalab/pydatalab/routes/__init__.py
+++ b/pydatalab/pydatalab/routes/__init__.py
@@ -1,3 +1,3 @@
-from pydatalab.routes.v0_1 import ENDPOINTS, __api_version__, auth
+from pydatalab.routes.v0_1 import BLUEPRINTS, ENDPOINTS, __api_version__, auth
 
-__all__ = ("ENDPOINTS", "__api_version__", "auth")
+__all__ = ("ENDPOINTS", "__api_version__", "auth", "BLUEPRINTS")

--- a/pydatalab/pydatalab/routes/v0_1/__init__.py
+++ b/pydatalab/pydatalab/routes/v0_1/__init__.py
@@ -3,6 +3,7 @@ from typing import Callable, Dict
 from ._version import __api_version__
 from .auth import ENDPOINTS as auth_endpoints
 from .blocks import ENDPOINTS as blocks_endpoints
+from .collections import collection
 from .files import ENDPOINTS as files_endpoints
 from .graphs import ENDPOINTS as graphs_endpoints
 from .healthcheck import ENDPOINTS as healthcheck_endpoints
@@ -21,4 +22,6 @@ ENDPOINTS: Dict[str, Callable] = {
     **info_endpoints,
 }
 
-__all__ = ("ENDPOINTS", "__api_version__")
+BLUEPRINTS = [collection]
+
+__all__ = ("ENDPOINTS", "BLUEPRINTS", "__api_version__")

--- a/pydatalab/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/pydatalab/routes/v0_1/blocks.py
@@ -70,19 +70,85 @@ def add_data_block():
 add_data_block.methods = ("POST",)  # type: ignore
 
 
+def add_collection_data_block():
+    """Call with AJAX to add a block to the collection."""
+
+    request_json = request.get_json()
+
+    # pull out required arguments from json
+    block_type = request_json["block_type"]
+    collection_id = request_json["collection_id"]
+    insert_index = request_json["index"]
+
+    if block_type not in BLOCK_TYPES:
+        return jsonify(status="error", message="Invalid block type"), 400
+
+    block = BLOCK_TYPES[block_type](collection_id=collection_id)
+
+    data = block.to_db()
+
+    # currently, adding to both blocks and blocks_obj to mantain compatibility with
+    # the old site. The new site only uses blocks_obj
+    if insert_index:
+        display_order_update = {
+            "$each": [block.block_id],
+            "$position": insert_index,
+        }
+    else:
+        display_order_update = block.block_id
+
+    result = flask_mongo.db.collections.update_one(
+        {"collection_id": collection_id, **get_default_permissions(user_only=True)},
+        {
+            "$push": {"blocks": data, "display_order": display_order_update},
+            "$set": {f"blocks_obj.{block.block_id}": data},
+        },
+    )
+
+    if result.modified_count < 1:
+        return (
+            jsonify(
+                status="error",
+                message=f"Update failed. {collection_id=} is probably incorrect.",
+            ),
+            400,
+        )
+
+    # get the new display_order:
+    display_order_result = flask_mongo.db.items.find_one(
+        {"collection_id": collection_id, **get_default_permissions(user_only=True)},
+        {"display_order": 1},
+    )
+
+    return jsonify(
+        status="success",
+        new_block_obj=block.to_web(),
+        new_block_insert_index=insert_index
+        if insert_index is None
+        else len(display_order_result["display_order"]) - 1,
+        new_display_order=display_order_result["display_order"],
+    )
+
+
 def _save_block_to_db(block: DataBlock) -> bool:
     """Save data for a single block within an item to the database,
     overwriting previous data saved there.
     returns true if successful, false if unsuccessful
     """
-    result = flask_mongo.db.items.update_one(
-        {"item_id": block.data["item_id"], **get_default_permissions(user_only=False)},
-        {"$set": {f"blocks_obj.{block.block_id}": block.to_db()}},
-    )
+    if block.data.get("item_id"):
+        result = flask_mongo.db.items.update_one(
+            {"item_id": block.data["item_id"], **get_default_permissions(user_only=False)},
+            {"$set": {f"blocks_obj.{block.block_id}": block.to_db()}},
+        )
+    elif block.data.get("collection_id"):
+        result = flask_mongo.db.collections.update_one(
+            {"item_id": block.data["collection_id"], **get_default_permissions(user_only=False)},
+            {"$set": {f"blocks_obj.{block.block_id}": block.to_db()}},
+        )
 
     if result.matched_count != 1:
         LOGGER.warning(
-            f"_save_block_to_db failed, likely because item_id ({block.data['item_id']}) and/or block_id ({block.block_id})  wasn't found"
+            f"_save_block_to_db failed, likely because item_id ({block.data.get('item_id')}), collection_id ({block.data.get('collection_id')}) and/or block_id ({block.block_id})  wasn't found"
         )
         return False
     else:
@@ -119,7 +185,7 @@ update_block.methods = ("POST",)  # type: ignore
 
 
 def delete_block():
-    """Completely delete a data block fron the database. In the future,
+    """Completely delete a data block from the database. In the future,
     we may consider preserving data by moving it to a different array,
     or simply making it invisible"""
     request_json = request.get_json()
@@ -155,8 +221,50 @@ def delete_block():
 
 delete_block.methods = ("POST",)  # type: ignore
 
+
+def delete_collection_block():
+    """Completely delete a data block from the database that is currently
+    attached to a collection.
+
+    In the future, we may consider preserving data by moving it to a different array,
+    or simply making it invisible"""
+    request_json = request.get_json()
+    collection_id = request_json["collection_id"]
+    block_id = request_json["block_id"]
+
+    result = flask_mongo.db.collections.update_one(
+        {"collection_id": collection_id, **get_default_permissions(user_only=True)},
+        {
+            "$pull": {
+                "blocks": {"block_id": block_id},
+                "display_order": block_id,
+            },
+            "$unset": {f"blocks_obj.{block_id}": ""},
+        },
+    )
+
+    if result.modified_count < 1:
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": f"Update failed. The collection_id probably incorrect: {collection_id}",
+                }
+            ),
+            400,
+        )
+    return (
+        jsonify({"status": "success"}),
+        200,
+    )
+
+
+delete_collection_block.methods = ("POST",)  # type: ignore
+
 ENDPOINTS: Dict[str, Callable] = {
     "/add-data-block/": add_data_block,
+    "/add-collection-data-block/": add_collection_data_block,
     "/update-block/": update_block,
     "/delete-block/": delete_block,
+    "/delete-collection-block/": delete_collection_block,
 }

--- a/pydatalab/pydatalab/routes/v0_1/collections.py
+++ b/pydatalab/pydatalab/routes/v0_1/collections.py
@@ -1,0 +1,330 @@
+import datetime
+import json
+
+from flask import Blueprint, jsonify, request
+from flask_login import current_user
+from pydantic import ValidationError
+from pymongo.results import InsertOneResult, UpdateResult
+
+from pydatalab.config import CONFIG
+from pydatalab.logger import logged_route
+from pydatalab.models.collections import Collection
+from pydatalab.mongo import flask_mongo
+from pydatalab.routes.utils import get_default_permissions
+from pydatalab.routes.v0_1.items import creators_lookup, get_samples_summary
+
+collection = Blueprint("collections", __name__)
+
+
+@collection.route("/collections/")
+def get_collections():
+
+    if not current_user.is_authenticated and not CONFIG.TESTING:
+        return (
+            jsonify(
+                status="error",
+                message="Authorization required to list collections.",
+            ),
+            401,
+        )
+
+    collections = flask_mongo.db.collections.aggregate(
+        [
+            {"$match": get_default_permissions(user_only=True)},
+            {"$lookup": creators_lookup()},
+            {"$project": {"_id": 0}},
+            {"$sort": {"_id": -1}},
+        ]
+    )
+
+    return jsonify({"status": "success", "data": list(collections)})
+
+
+@collection.route("/collections/<collection_id>", methods=["GET"])
+def get_collection(collection_id):
+
+    collection = flask_mongo.db.collections.aggregate(
+        [
+            {
+                "$match": {
+                    "collection_id": collection_id,
+                    **get_default_permissions(user_only=True),
+                }
+            },
+            {"$lookup": creators_lookup()},
+            {"$sort": {"_id": -1}},
+        ]
+    )
+
+    collection = Collection(**list(collection)[0])
+
+    samples = list(
+        get_samples_summary(
+            match={
+                "relationships.type": "collections",
+                "relationships.immutable_id": collection.immutable_id,
+            },
+            project={"collections": 0},
+        )
+    )
+
+    collection.num_items = len(samples)
+
+    return jsonify(
+        {
+            "status": "success",
+            "collection_id": collection_id,
+            "data": json.loads(collection.json(exclude_unset=True)),
+            "child_items": list(samples),
+        }
+    )
+
+
+@collection.route("/collections/", methods=["PUT"])
+def create_collection():
+    request_json = request.get_json()  # noqa: F821 pylint: disable=undefined-variable
+    data = request_json.get("data", {})
+    copy_from_id = request_json.get("copy_from_collection_id", None)
+    starting_members = data.get("starting_members", [])
+
+    if not current_user.is_authenticated and not CONFIG.TESTING:
+        return (
+            dict(
+                status="error",
+                message="Unable to create new collection without user authentication.",
+                collection_id=data.get("collection_id"),
+            ),
+            401,
+        )
+
+    if copy_from_id:
+        raise NotImplementedError("Copying collections is not yet implemented.")
+
+    if CONFIG.TESTING:
+        data["creator_ids"] = []
+        data["creators"] = [
+            {"display_name": "Public testing user", "contact_email": "datalab@odbx.science"}
+        ]
+    else:
+        data["creator_ids"] = [current_user.person.immutable_id]
+        data["creators"] = [
+            {
+                "display_name": current_user.person.display_name,
+                "contact_email": current_user.person.contact_email,
+            }
+        ]
+
+    # check to make sure that item_id isn't taken already
+    if flask_mongo.db.collections.find_one({"collection_id": data["collection_id"]}):
+        return (
+            dict(
+                status="error",
+                message=f"collection_id_validation_error: {data['collection_id']!r} already exists in database.",
+                collection_id=data["collection_id"],
+            ),
+            409,  # 409: Conflict
+        )
+
+    data["date"] = data.get("date", datetime.datetime.now())
+
+    try:
+        data_model = Collection(**data)
+
+    except ValidationError as error:
+        return (
+            dict(
+                status="error",
+                message=f"Unable to create new collection with ID {data['collection_id']}.",
+                item_id=data["collection_id"],
+                output=str(error),
+            ),
+            400,
+        )
+
+    result: InsertOneResult = flask_mongo.db.collections.insert_one(
+        data_model.dict(exclude_unset=True)
+    )
+    if not result.acknowledged:
+        return (
+            dict(
+                status="error",
+                message=f"Failed to add new collection {data['collection_id']!r} to database.",
+                collection_id=data["collection_id"],
+                output=result.raw_result,
+            ),
+            400,
+        )
+
+    immutable_id = result.inserted_id
+
+    errors = []
+    if starting_members:
+        item_ids = set(d.get("item_id") for d in starting_members)
+        if None in item_ids:
+            item_ids.remove(None)
+
+        results: UpdateResult = flask_mongo.db.items.update_many(
+            {
+                "item_id": {"$in": list(item_ids)},
+                **get_default_permissions(user_only=True),
+            },
+            {"$push": {"relationships": {"type": "collections", "immutable_id": immutable_id}}},
+        )
+
+        data_model.num_items = results.modified_count
+
+        if results.modified_count < len(starting_members):
+            errors = [
+                item_id
+                for item_id in starting_members
+                if item_id not in results.raw_result.get("upserted", [])
+            ]
+
+    else:
+        data_model.num_items = 0
+
+    response = {
+        "status": "success",
+        "data": json.loads(data_model.json()),
+    }
+
+    if errors:
+        response["warnings"] = [
+            f"Unable to register {errors} to new collection {data_model.collection_id}"
+        ]
+
+    return (
+        jsonify(response),
+        201,  # 201: Created
+    )
+
+
+@collection.route("/collections/<collection_id>", methods=["PATCH"])
+@logged_route
+def save_collection(collection_id):
+
+    request_json = request.get_json()  # noqa: F821 pylint: disable=undefined-variable
+    updated_data = request_json.get("data")
+
+    if not updated_data:
+        return (
+            jsonify(
+                status="error",
+                message=f"Unable to find any data in request to update {collection_id=} with.",
+            ),
+            204,  # 204: No content
+        )
+
+    # These keys should not be updated here and cannot be modified by the user through this endpoint
+    for k in ("_id", "file_ObjectIds", "creators", "creator_ids", "collection_id"):
+        if k in updated_data:
+            del updated_data[k]
+
+    updated_data["last_modified"] = datetime.datetime.now().isoformat()
+
+    collection = flask_mongo.db.collections.find_one(
+        {"collection_id": collection_id, **get_default_permissions(user_only=True)}
+    )
+
+    if not collection:
+        return (
+            jsonify(
+                status="error",
+                message=f"Unable to find item with appropriate permissions and {collection_id=}.",
+            ),
+            400,
+        )
+
+    collection.update(updated_data)
+
+    try:
+        collection = Collection(**collection).dict()
+    except ValidationError as exc:
+        return (
+            jsonify(
+                status="error",
+                message=f"Unable to update item {collection_id=} with new data {updated_data}",
+                output=str(exc),
+            ),
+            400,
+        )
+
+    result: UpdateResult = flask_mongo.db.collections.update_one(
+        {"collection_id": collection_id},
+        {"$set": collection},
+    )
+
+    if result.modified_count != 1:
+        return (
+            jsonify(
+                status="error",
+                message=f"Unable to update item {collection_id=} with new data {updated_data}",
+                output=result.raw_result,
+            ),
+            400,
+        )
+
+    return jsonify(status="success"), 200
+
+
+@collection.route("/collections/<collection_id>", methods=["DELETE"])
+def delete_collection(collection_id: str):
+
+    if not current_user.is_authenticated and not CONFIG.TESTING:
+        return (
+            jsonify(
+                status="error",
+                message="Authorization required to delete collections.",
+            ),
+            401,
+        )
+
+    result = flask_mongo.db.collections.delete_one(
+        {"collection_id": collection_id, **get_default_permissions(user_only=True)}
+    )
+
+    if result.deleted_count != 1:
+        return (
+            jsonify(
+                {
+                    "status": "error",
+                    "message": f"Authorization required to attempt to delete collection with {collection_id=} from the database.",
+                }
+            ),
+            401,
+        )
+    return (
+        jsonify(
+            {
+                "status": "success",
+            }
+        ),
+        200,
+    )
+
+
+@collection.route("/search-collections/", methods=["GET"])
+def search_collections():
+    query = request.args.get("query", type=str)
+    nresults = request.args.get("nresults", default=100, type=int)
+
+    match_obj = {"$text": {"$search": query}, **get_default_permissions(user_only=True)}
+
+    cursor = [
+        json.loads(Collection(**doc).json(exclude_unset=True))
+        for doc in flask_mongo.db.collections.aggregate(
+            [
+                {"$match": match_obj},
+                {"$sort": {"score": {"$meta": "textScore"}}},
+                {"$limit": nresults},
+                {
+                    "$project": {
+                        "collection_id": 1,
+                        "title": 1,
+                    }
+                },
+            ]
+        )
+    ]
+
+    return jsonify({"status": "success", "data": list(cursor)}), 200

--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -1,11 +1,12 @@
 import datetime
 import json
-from typing import Callable, Dict, List, Set, Union
+from typing import Callable, Dict, List, Optional, Set, Union
 
 from bson import ObjectId
 from flask import jsonify, request
 from flask_login import current_user
 from pydantic import ValidationError
+from pymongo.command_cursor import CommandCursor
 
 from pydatalab.blocks import BLOCK_TYPES
 from pydatalab.config import CONFIG
@@ -115,47 +116,113 @@ def get_starting_materials():
 get_starting_materials.methods = ("GET",)  # type: ignore
 
 
+def get_samples_summary(
+    match: Optional[Dict] = None, project: Optional[Dict] = None
+) -> CommandCursor:
+    """Return a summary of item entries that match some criteria.
+
+    Parameters:
+        match: A MongoDB aggregation match query to filter the results.
+        project: A MongoDB aggregation project query to filter the results, relative
+            to the default included below.
+
+    """
+    if not match:
+        match = {}
+    match.update(get_default_permissions(user_only=False))
+    match["type"] = {"$in": ["samples", "cells"]}
+
+    _project = {
+        "_id": 0,
+        "creators": {
+            "display_name": 1,
+            "contact_email": 1,
+        },
+        "collections": {
+            "collection_id": 1,
+            "title": 1,
+        },
+        "item_id": 1,
+        "name": 1,
+        "chemform": 1,
+        "characteristic_chemical_formula": 1,
+        "type": 1,
+        "date": 1,
+        "refcode": 1,
+    }
+
+    # Cannot mix 0 and 1 keys in MongoDB project so must loop and check
+    if project:
+        for key in project:
+            if project[key] == 0:
+                _project.pop(key, None)
+            else:
+                _project[key] = 1
+
+    return flask_mongo.db.items.aggregate(
+        [
+            {"$match": match},
+            {"$lookup": creators_lookup()},
+            {"$lookup": collections_lookup()},
+            {"$project": _project},
+            {"$sort": {"_id": -1}},
+        ]
+    )
+
+
+def creators_lookup() -> Dict:
+    return {
+        "from": "users",
+        "let": {"creator_ids": "$creator_ids"},
+        "pipeline": [
+            {
+                "$match": {
+                    "$expr": {
+                        "$in": ["$_id", "$$creator_ids"],
+                    },
+                }
+            },
+            {"$project": {"_id": 0, "display_name": 1, "contact_email": 1}},
+        ],
+        "as": "creators",
+    }
+
+
+def files_lookup() -> Dict:
+    return {
+        "from": "files",
+        "localField": "file_ObjectIds",
+        "foreignField": "_id",
+        "as": "files",
+    }
+
+
+def collections_lookup() -> Dict:
+    """Looks inside the relationships of the item, searches for IDs in the collections
+    table and then projects only the collection ID and name for the response.
+
+    """
+
+    return {
+        "from": "collections",
+        "let": {"collection_ids": "$relationships.immutable_id"},
+        "pipeline": [
+            {
+                "$match": {
+                    "$expr": {
+                        "$in": ["$_id", "$$collection_ids"],
+                    },
+                    "type": "collections",
+                }
+            },
+            {"$project": {"_id": 1, "collection_id": 1}},
+        ],
+        "as": "collections",
+    }
+
+
 def get_samples():
-    items = [
-        doc
-        for doc in flask_mongo.db.items.aggregate(
-            [
-                {
-                    "$match": {
-                        "type": {"$in": ["samples", "cells"]},
-                        **get_default_permissions(user_only=False),
-                    }
-                },
-                {
-                    "$lookup": {
-                        "from": "users",
-                        "localField": "creator_ids",
-                        "foreignField": "_id",
-                        "as": "creators",
-                    }
-                },
-                {"$sort": {"date": -1}},
-                {
-                    "$project": {
-                        "_id": 0,
-                        "item_id": 1,
-                        "refcode": 1,
-                        "type": 1,
-                        "sample_id": 1,
-                        "nblocks": {"$size": "$display_order"},
-                        "creators": {
-                            "display_name": 1,
-                            "contact_email": 1,
-                        },
-                        "date": 1,
-                        "chemform": 1,
-                        "name": 1,
-                    }
-                },
-            ]
-        )
-    ]
-    return jsonify({"status": "success", "samples": items})
+    return jsonify({"status": "success", "samples": list(get_samples_summary())})
 
 
 get_samples.methods = ("GET",)  # type: ignore
@@ -208,7 +275,8 @@ def search_items():
 search_items.methods = ("GET",)  # type: ignore
 
 
-def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[dict, int]:
+def _create_sample(sample_dict: dict, copy_from_item_id: Optional[str] = None) -> tuple[dict, int]:
+
     if not current_user.is_authenticated and not CONFIG.TESTING:
         return (
             dict(
@@ -289,7 +357,9 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
     new_sample = {k: sample_dict[k] for k in schema["properties"] if k in sample_dict}
 
     if CONFIG.TESTING:
-        new_sample["creator_ids"] = []
+        # Set fake ID to ObjectId("000000000000000000000000") so a dummy user can be created
+        # locally for testing creator UI elements
+        new_sample["creator_ids"] = [24 * "0"]
         new_sample["creators"] = [
             {"display_name": "Public testing user", "contact_email": "datalab@odbx.science"}
         ]
@@ -324,14 +394,18 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
         return (
             dict(
                 status="error",
-                message=f"Unable to create new item with ID {new_sample['item_id']}.",
+                message=f"Unable to create new item with ID {new_sample['item_id']}: {str(error)}.",
                 item_id=new_sample["item_id"],
                 output=str(error),
             ),
             400,
         )
 
-    result = flask_mongo.db.items.insert_one(data_model.dict())
+    # Do not store the fields `collections` or `creators` in the dataabse as these should be populated
+    # via joins for a specific query.
+    # TODO: encode this at the model level, via custom schema properties or hard-coded `.store()` methods
+    # the `Entry` model.
+    result = flask_mongo.db.items.insert_one(data_model.dict(exclude={"creators", "collections"}))
     if not result.acknowledged:
         return (
             dict(
@@ -343,7 +417,7 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
             400,
         )
 
-    return (
+    data = (
         {
             "status": "success",
             "item_id": data_model.item_id,
@@ -354,14 +428,23 @@ def _create_sample(sample_dict: dict, copy_from_item_id: str = None) -> tuple[di
                 "date": data_model.date,
                 "name": data_model.name,
                 "creator_ids": data_model.creator_ids,
+                # TODO: This workaround for creators & collections is still gross, need to figure this out properly
                 "creators": [json.loads(c.json(exclude_unset=True)) for c in data_model.creators]
                 if data_model.creators
+                else [],
+                "collections": [
+                    json.loads(c.json(exclude_unset=True, exclude_none=True))
+                    for c in data_model.collections
+                ]
+                if data_model.collections
                 else [],
                 "type": data_model.type,
             },
         },
         201,  # 201: Created
     )
+
+    return data
 
 
 def create_sample():
@@ -452,22 +535,9 @@ def get_item_data(item_id, load_blocks=True):
     cursor = flask_mongo.db.items.aggregate(
         [
             {"$match": {"item_id": item_id, **get_default_permissions(user_only=False)}},
-            {
-                "$lookup": {
-                    "from": "users",
-                    "localField": "creator_ids",
-                    "foreignField": "_id",
-                    "as": "creators",
-                },
-            },
-            {
-                "$lookup": {
-                    "from": "files",
-                    "localField": "file_ObjectIds",
-                    "foreignField": "_id",
-                    "as": "files",
-                }
-            },
+            {"$lookup": creators_lookup()},
+            {"$lookup": collections_lookup()},
+            {"$lookup": files_lookup()},
         ],
     )
 
@@ -476,11 +546,7 @@ def get_item_data(item_id, load_blocks=True):
     except IndexError:
         doc = None
 
-    if not doc or (
-        not CONFIG.TESTING
-        and not current_user.is_authenticated
-        and doc["type"] == "starting_materials"
-    ):
+    if not doc or (not current_user.is_authenticated and doc["type"] == "starting_materials"):
         return (
             jsonify(
                 {
@@ -510,6 +576,7 @@ def get_item_data(item_id, load_blocks=True):
             "$or": [
                 {"relationships.item_id": doc.item_id},
                 {"relationships.refcode": doc.refcode},
+                {"relationships.immutable_id": doc.immutable_id},
             ]
         },
         projection={
@@ -532,13 +599,19 @@ def get_item_data(item_id, load_blocks=True):
         for k in d["relationships"]:
             if k["relation"] not in incoming_relationships:
                 incoming_relationships[k["relation"]] = set()
-            incoming_relationships[k["relation"]].add(d["item_id"] or d["refcode"])
+            incoming_relationships[k["relation"]].add(
+                d["item_id"] or d["refcode"] or d["immutable_id"]
+            )
 
     # loop over and aggregate all 'inner' relationships presented by this item
     inlined_relationships: Dict[RelationshipType, Set[str]] = {}
     if doc.relationships is not None:
         inlined_relationships = {
-            relation: {d.item_id or d.refcode for d in doc.relationships if d.relation == relation}
+            relation: {
+                d.item_id or d.refcode or d.immutable_id
+                for d in doc.relationships
+                if d.relation == relation
+            }
             for relation in RelationshipType
         }
 
@@ -551,11 +624,11 @@ def get_item_data(item_id, load_blocks=True):
     )
 
     # Must be exported to JSON first to apply the custom pydantic JSON encoders
-    return_dict = json.loads(doc.json())
+    return_dict = json.loads(doc.json(exclude_unset=True))
 
     # create the files_data dictionary keyed by file ObjectId
     files_data: Dict[ObjectId, Dict] = dict(
-        [(f["immutable_id"], f) for f in return_dict.get("files", [])]
+        [(f["immutable_id"], f) for f in return_dict.get("files") or []]
     )
 
     return jsonify(
@@ -580,7 +653,7 @@ def save_item():
     updated_data = request_json["data"]
 
     # These keys should not be updated here and cannot be modified by the user through this endpoint
-    for k in ("_id", "file_ObjectIds", "creators", "creator_ids"):
+    for k in ("_id", "file_ObjectIds", "creators", "creator_ids", "item_id"):
         if k in updated_data:
             del updated_data[k]
 
@@ -620,6 +693,10 @@ def save_item():
             ),
             400,
         )
+
+    # remove collections and creators and any other reference fields
+    item.pop("collections")
+    item.pop("creators")
 
     result = flask_mongo.db.items.update_one(
         {"item_id": item_id},

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -3,6 +3,51 @@
   "description": "A model for representing electrochemical cells.",
   "type": "object",
   "properties": {
+    "blocks_obj": {
+      "title": "Blocks Obj",
+      "default": {},
+      "type": "object"
+    },
+    "display_order": {
+      "title": "Display Order",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "collections": {
+      "title": "Collections",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Collection"
+      }
+    },
+    "revision": {
+      "title": "Revision",
+      "default": 1,
+      "type": "integer"
+    },
+    "revisions": {
+      "title": "Revisions",
+      "type": "object"
+    },
+    "creator_ids": {
+      "title": "Creator Ids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "creators": {
+      "title": "Creators",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Person"
+      }
+    },
     "type": {
       "title": "Type",
       "default": "cells",
@@ -26,15 +71,6 @@
         "$ref": "#/definitions/TypedRelationship"
       }
     },
-    "revision": {
-      "title": "Revision",
-      "default": 1,
-      "type": "integer"
-    },
-    "revisions": {
-      "title": "Revisions",
-      "type": "object"
-    },
     "refcode": {
       "title": "Refcode",
       "minLength": 1,
@@ -49,21 +85,6 @@
       "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
       "type": "string"
     },
-    "creator_ids": {
-      "title": "Creator Ids",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "creators": {
-      "title": "Creators",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Person"
-      }
-    },
     "description": {
       "title": "Description",
       "type": "string"
@@ -76,19 +97,6 @@
     "name": {
       "title": "Name",
       "type": "string"
-    },
-    "blocks_obj": {
-      "title": "Blocks Obj",
-      "default": {},
-      "type": "object"
-    },
-    "display_order": {
-      "title": "Display Order",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
     },
     "files": {
       "title": "Files",
@@ -191,7 +199,8 @@
         "starting_materials",
         "blocks",
         "files",
-        "people"
+        "people",
+        "collections"
       ],
       "type": "string"
     },
@@ -243,7 +252,6 @@
         }
       },
       "required": [
-        "relation",
         "type"
       ]
     },
@@ -316,15 +324,6 @@
             "$ref": "#/definitions/TypedRelationship"
           }
         },
-        "revision": {
-          "title": "Revision",
-          "default": 1,
-          "type": "integer"
-        },
-        "revisions": {
-          "title": "Revisions",
-          "type": "object"
-        },
         "identities": {
           "title": "Identities",
           "type": "array",
@@ -342,6 +341,86 @@
           "format": "email"
         }
       }
+    },
+    "Collection": {
+      "title": "Collection",
+      "description": "An Entry is an abstract base class for any model that can be\ndeserialized and stored in the database.",
+      "type": "object",
+      "properties": {
+        "blocks_obj": {
+          "title": "Blocks Obj",
+          "default": {},
+          "type": "object"
+        },
+        "display_order": {
+          "title": "Display Order",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creator_ids": {
+          "title": "Creator Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creators": {
+          "title": "Creators",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Person"
+          }
+        },
+        "type": {
+          "title": "Type",
+          "default": "collections",
+          "const": "collections",
+          "pattern": "^collections$",
+          "type": "string"
+        },
+        "immutable_id": {
+          "title": "Immutable ID",
+          "type": "string"
+        },
+        "last_modified": {
+          "title": "Last Modified",
+          "type": "date",
+          "format": "date-time"
+        },
+        "relationships": {
+          "title": "Relationships",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TypedRelationship"
+          }
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "minLength": 1,
+          "maxLength": 40,
+          "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "num_items": {
+          "title": "Num Items",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "collection_id"
+      ]
     },
     "File": {
       "title": "File",
@@ -370,15 +449,6 @@
           "items": {
             "$ref": "#/definitions/TypedRelationship"
           }
-        },
-        "revision": {
-          "title": "Revision",
-          "default": 1,
-          "type": "integer"
-        },
-        "revisions": {
-          "title": "Revisions",
-          "type": "object"
         },
         "size": {
           "title": "Size",

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -3,6 +3,51 @@
   "description": "A model for representing an experimental sample.",
   "type": "object",
   "properties": {
+    "blocks_obj": {
+      "title": "Blocks Obj",
+      "default": {},
+      "type": "object"
+    },
+    "display_order": {
+      "title": "Display Order",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "collections": {
+      "title": "Collections",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Collection"
+      }
+    },
+    "revision": {
+      "title": "Revision",
+      "default": 1,
+      "type": "integer"
+    },
+    "revisions": {
+      "title": "Revisions",
+      "type": "object"
+    },
+    "creator_ids": {
+      "title": "Creator Ids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "creators": {
+      "title": "Creators",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Person"
+      }
+    },
     "type": {
       "title": "Type",
       "default": "samples",
@@ -26,15 +71,6 @@
         "$ref": "#/definitions/TypedRelationship"
       }
     },
-    "revision": {
-      "title": "Revision",
-      "default": 1,
-      "type": "integer"
-    },
-    "revisions": {
-      "title": "Revisions",
-      "type": "object"
-    },
     "refcode": {
       "title": "Refcode",
       "minLength": 1,
@@ -49,21 +85,6 @@
       "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
       "type": "string"
     },
-    "creator_ids": {
-      "title": "Creator Ids",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "creators": {
-      "title": "Creators",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Person"
-      }
-    },
     "description": {
       "title": "Description",
       "type": "string"
@@ -76,19 +97,6 @@
     "name": {
       "title": "Name",
       "type": "string"
-    },
-    "blocks_obj": {
-      "title": "Blocks Obj",
-      "default": {},
-      "type": "object"
-    },
-    "display_order": {
-      "title": "Display Order",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
     },
     "files": {
       "title": "Files",
@@ -150,7 +158,8 @@
         "starting_materials",
         "blocks",
         "files",
-        "people"
+        "people",
+        "collections"
       ],
       "type": "string"
     },
@@ -202,7 +211,6 @@
         }
       },
       "required": [
-        "relation",
         "type"
       ]
     },
@@ -275,15 +283,6 @@
             "$ref": "#/definitions/TypedRelationship"
           }
         },
-        "revision": {
-          "title": "Revision",
-          "default": 1,
-          "type": "integer"
-        },
-        "revisions": {
-          "title": "Revisions",
-          "type": "object"
-        },
         "identities": {
           "title": "Identities",
           "type": "array",
@@ -301,6 +300,86 @@
           "format": "email"
         }
       }
+    },
+    "Collection": {
+      "title": "Collection",
+      "description": "An Entry is an abstract base class for any model that can be\ndeserialized and stored in the database.",
+      "type": "object",
+      "properties": {
+        "blocks_obj": {
+          "title": "Blocks Obj",
+          "default": {},
+          "type": "object"
+        },
+        "display_order": {
+          "title": "Display Order",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creator_ids": {
+          "title": "Creator Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creators": {
+          "title": "Creators",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Person"
+          }
+        },
+        "type": {
+          "title": "Type",
+          "default": "collections",
+          "const": "collections",
+          "pattern": "^collections$",
+          "type": "string"
+        },
+        "immutable_id": {
+          "title": "Immutable ID",
+          "type": "string"
+        },
+        "last_modified": {
+          "title": "Last Modified",
+          "type": "date",
+          "format": "date-time"
+        },
+        "relationships": {
+          "title": "Relationships",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TypedRelationship"
+          }
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "minLength": 1,
+          "maxLength": 40,
+          "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "num_items": {
+          "title": "Num Items",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "collection_id"
+      ]
     },
     "File": {
       "title": "File",
@@ -329,15 +408,6 @@
           "items": {
             "$ref": "#/definitions/TypedRelationship"
           }
-        },
-        "revision": {
-          "title": "Revision",
-          "default": 1,
-          "type": "integer"
-        },
-        "revisions": {
-          "title": "Revisions",
-          "type": "object"
         },
         "size": {
           "title": "Size",

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -3,6 +3,51 @@
   "description": "A model for representing an experimental sample.",
   "type": "object",
   "properties": {
+    "blocks_obj": {
+      "title": "Blocks Obj",
+      "default": {},
+      "type": "object"
+    },
+    "display_order": {
+      "title": "Display Order",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "collections": {
+      "title": "Collections",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Collection"
+      }
+    },
+    "revision": {
+      "title": "Revision",
+      "default": 1,
+      "type": "integer"
+    },
+    "revisions": {
+      "title": "Revisions",
+      "type": "object"
+    },
+    "creator_ids": {
+      "title": "Creator Ids",
+      "default": [],
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "creators": {
+      "title": "Creators",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/Person"
+      }
+    },
     "type": {
       "title": "Type",
       "default": "starting_materials",
@@ -26,15 +71,6 @@
         "$ref": "#/definitions/TypedRelationship"
       }
     },
-    "revision": {
-      "title": "Revision",
-      "default": 1,
-      "type": "integer"
-    },
-    "revisions": {
-      "title": "Revisions",
-      "type": "object"
-    },
     "refcode": {
       "title": "Refcode",
       "minLength": 1,
@@ -49,21 +85,6 @@
       "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
       "type": "string"
     },
-    "creator_ids": {
-      "title": "Creator Ids",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "creators": {
-      "title": "Creators",
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Person"
-      }
-    },
     "description": {
       "title": "Description",
       "type": "string"
@@ -77,19 +98,6 @@
       "title": "Container Name",
       "description": "name of the chemical",
       "type": "string"
-    },
-    "blocks_obj": {
-      "title": "Blocks Obj",
-      "default": {},
-      "type": "object"
-    },
-    "display_order": {
-      "title": "Display Order",
-      "default": [],
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
     },
     "files": {
       "title": "Files",
@@ -201,7 +209,8 @@
         "starting_materials",
         "blocks",
         "files",
-        "people"
+        "people",
+        "collections"
       ],
       "type": "string"
     },
@@ -253,7 +262,6 @@
         }
       },
       "required": [
-        "relation",
         "type"
       ]
     },
@@ -326,15 +334,6 @@
             "$ref": "#/definitions/TypedRelationship"
           }
         },
-        "revision": {
-          "title": "Revision",
-          "default": 1,
-          "type": "integer"
-        },
-        "revisions": {
-          "title": "Revisions",
-          "type": "object"
-        },
         "identities": {
           "title": "Identities",
           "type": "array",
@@ -352,6 +351,86 @@
           "format": "email"
         }
       }
+    },
+    "Collection": {
+      "title": "Collection",
+      "description": "An Entry is an abstract base class for any model that can be\ndeserialized and stored in the database.",
+      "type": "object",
+      "properties": {
+        "blocks_obj": {
+          "title": "Blocks Obj",
+          "default": {},
+          "type": "object"
+        },
+        "display_order": {
+          "title": "Display Order",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creator_ids": {
+          "title": "Creator Ids",
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "creators": {
+          "title": "Creators",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/Person"
+          }
+        },
+        "type": {
+          "title": "Type",
+          "default": "collections",
+          "const": "collections",
+          "pattern": "^collections$",
+          "type": "string"
+        },
+        "immutable_id": {
+          "title": "Immutable ID",
+          "type": "string"
+        },
+        "last_modified": {
+          "title": "Last Modified",
+          "type": "date",
+          "format": "date-time"
+        },
+        "relationships": {
+          "title": "Relationships",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/TypedRelationship"
+          }
+        },
+        "collection_id": {
+          "title": "Collection Id",
+          "minLength": 1,
+          "maxLength": 40,
+          "pattern": "^(?:[a-zA-Z0-9]+|[a-zA-Z0-9][a-zA-Z0-9._-]+[a-zA-Z0-9])$",
+          "type": "string"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "description": {
+          "title": "Description",
+          "type": "string"
+        },
+        "num_items": {
+          "title": "Num Items",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "collection_id"
+      ]
     },
     "File": {
       "title": "File",
@@ -380,15 +459,6 @@
           "items": {
             "$ref": "#/definitions/TypedRelationship"
           }
-        },
-        "revision": {
-          "title": "Revision",
-          "default": 1,
-          "type": "integer"
-        },
-        "revisions": {
-          "title": "Revisions",
-          "type": "object"
         },
         "size": {
           "title": "Size",

--- a/pydatalab/tests/conftest.py
+++ b/pydatalab/tests/conftest.py
@@ -8,7 +8,7 @@ import pytest
 
 import pydatalab.mongo
 from pydatalab.main import create_app
-from pydatalab.models import Cell, Sample, StartingMaterial
+from pydatalab.models import Cell, Collection, Sample, StartingMaterial
 
 TEST_DATABASE_NAME = "datalab-testing"
 
@@ -114,7 +114,7 @@ def fixture_default_sample():
 
 
 @pytest.fixture(scope="module", name="default_cell")
-def fixture_default_cell(default_sample):
+def fixture_default_cell():
     return Cell(
         **{
             "item_id": "test_cell",
@@ -142,6 +142,18 @@ def fixture_default_cell(default_sample):
             "electrolyte": [{"item": {"name": "inlined reference"}, "quantity": 100, "unit": "ml"}],
             "cell_format": "swagelok",
             "type": "cells",
+        }
+    )
+
+
+@pytest.fixture(scope="module", name="default_collection")
+def fixture_default_collection():
+    return Collection(
+        **{
+            "collection_id": "test_collection",
+            "title": "My Test Collection",
+            "date": "1970-02-02",
+            "type": "collections",
         }
     )
 

--- a/pydatalab/tests/routers/test_samples.py
+++ b/pydatalab/tests/routers/test_samples.py
@@ -1,3 +1,4 @@
+import copy
 import datetime
 import json
 
@@ -388,22 +389,63 @@ def test_create_cell(client, default_cell):
     assert response.status_code == 201, response.json
     assert response.json["status"] == "success"
 
-    response = client.get(
-        f"/get-item-data/{default_cell.item_id}",
+
+@pytest.mark.dependency(depends=["test_create_cell"])
+def test_create_collections(client, default_collection):
+
+    # Check no collections initially
+    response = client.get("/collections/")
+    assert len(response.json["data"]) == 0, response.json
+    assert response.status_code == 200
+
+    # Create an empty collection
+    response = client.put("/collections/", json={"data": json.loads(default_collection.json())})
+    assert response.status_code == 201, response.json
+    assert response.json["status"] == "success"
+    assert response.json["data"]["collection_id"] == "test_collection"
+    assert response.json["data"]["title"] == "My Test Collection"
+    assert response.json["data"]["num_items"] == 0
+
+    response = client.get("/collections/")
+    assert response.status_code == 200
+    assert len(response.json["data"]) == 1
+    assert response.json["data"][0]["collection_id"] == "test_collection"
+    assert response.json["data"][0]["title"] == "My Test Collection"
+    assert response.status_code == 200
+
+    # Create a collection with initial items
+    new_collection = copy.deepcopy(default_collection)
+    new_collection.collection_id = "test_collection_2"
+
+    data = json.loads(new_collection.json())
+    data.update(
+        {
+            "starting_members": [
+                {"item_id": "copy_of_complicated_cell"},
+                {"item_id": "test_cell"},
+            ]
+        }
     )
+    response = client.put("/collections/", json={"data": data})
+    assert response.status_code == 201, response.json
+    assert response.json["status"] == "success"
+    assert response.json["data"]["collection_id"] == "test_collection_2"
+    assert response.json["data"]["title"] == "My Test Collection"
+    assert response.json["data"]["num_items"] == 2
 
-    assert response.json["item_data"]["electrolyte"] == [
-        {"item": {"chemform": None, "name": "inlined reference"}, "quantity": 100, "unit": "ml"},
-    ]
+    response = client.get(f"/collections/{new_collection.collection_id}")
 
-    assert len(response.json["item_data"]["electrolyte"]) == 1
-    assert len(response.json["item_data"]["positive_electrode"]) == 1
-    assert len(response.json["item_data"]["negative_electrode"]) == 2
+    assert response.status_code == 200, response.json
+    assert response.json["status"] == "success"
+    assert response.json["collection_id"] == "test_collection_2"
+    assert response.json["data"]["collection_id"] == "test_collection_2"
+    assert response.json["data"]["title"] == "My Test Collection"
+    assert response.json["data"]["num_items"] == 2
+    ids = {doc["item_id"] for doc in response.json["child_items"]}
+    assert ids == {"copy_of_complicated_cell", "test_cell"}
 
-    copied_response = client.get(
-        f"/get-item-data/{test_id}",
-    )
-
-    assert len(copied_response.json["item_data"]["electrolyte"]) == 2
-    assert len(copied_response.json["item_data"]["positive_electrode"]) == 1
-    assert len(copied_response.json["item_data"]["negative_electrode"]) == 2
+    response = client.get(f"/get-item-data/{ids.pop()}")
+    assert response.status_code == 200, response.json
+    assert response.json["status"] == "success"
+    assert len(response.json["item_data"]["collections"]) == 1
+    assert response.json["item_data"]["collections"][0]["collection_id"] == "test_collection_2"


### PR DESCRIPTION
This PR takes all Python changes from #292 and separates them into a new PR.

Few things left to check/discuss:

- [ ] Add a test for adding an existing item to an existing collection
- [ ] Collections can currently share `item_ids` -- should we make this unique across all users for future-proofing? This would be the simplest constraint for now
- [ ] Need to add tests for adding blocks to a collection