### PR TITLE
NMR block process number bugfix

### DIFF
--- a/pydatalab/pydatalab/blocks/blocks.py
+++ b/pydatalab/pydatalab/blocks/blocks.py
@@ -255,7 +255,7 @@ class NMRBlock(DataBlock):
                 process_number=self.data["selected_process"],
                 verbose=False,
             )
-        except (OSError, KeyError) as error:
+        except Exception as error:
             LOGGER.critical(f"Unable to parse {name} as Bruker project. {error}")
             return
 

--- a/pydatalab/pydatalab/blocks/blocks.py
+++ b/pydatalab/pydatalab/blocks/blocks.py
@@ -246,7 +246,7 @@ class NMRBlock(DataBlock):
         extracted_directory_name = os.path.join(directory_location, name)
         available_processes = os.listdir(os.path.join(extracted_directory_name, "pdata"))
 
-        if "selected_process" not in self.data:
+        if self.data.get("selected_process") not in available_processes:
             self.data["selected_process"] = available_processes[0]
 
         try:
@@ -255,8 +255,8 @@ class NMRBlock(DataBlock):
                 process_number=self.data["selected_process"],
                 verbose=False,
             )
-        except Exception:
-            LOGGER.critical(f"Unable to parse {name} as Bruker project.")
+        except (OSError, KeyError) as error:
+            LOGGER.critical(f"Unable to parse {name} as Bruker project. {error}")
             return
 
         serialized_df = df.to_dict() if (df is not None) else None


### PR DESCRIPTION
Bruker NMR files can each have a different set of "process numbers". This PR is a small bugfix to automatically select an existing process if the block has an invalid process number selected for any reason ( _i.e._ if the filename has just been changed and the selected process is not a valid process number in the new experiment).

Closes #402 
