### PR TITLE
make website title setable by environment variable

### DIFF
--- a/webapp/vue.config.js
+++ b/webapp/vue.config.js
@@ -11,4 +11,10 @@ module.exports = {
       type: "javascript/auto",
     });
   },
+  chainWebpack: (config) => {
+    config.plugin("html").tap((args) => {
+      args[0].title = process.env.VUE_APP_WEBSITE_TITLE || "datalab";
+      return args;
+    });
+  },
 };


### PR DESCRIPTION
The website title has previously been set to the webpack package name. This change allows it to be configured using the `VUE_APP_WEBSITE_TITLE` environment variable. If this variable is not set, defaults to "datalab".

Example use:

in `.env`:
```bash
VUE_APP_WEBSITE_TITLE="datalab - Grey group"
```