### PR TITLE
Add concept of user manager permissions

### DIFF
--- a/pydatalab/pydatalab/models/people.py
+++ b/pydatalab/pydatalab/models/people.py
@@ -6,6 +6,7 @@ import bson.errors
 from pydantic import BaseModel, EmailStr, Field, validator
 
 from pydatalab.models.entries import Entry
+from pydatalab.models.utils import PyObjectId
 
 
 class IdentityType(str, Enum):
@@ -75,6 +76,9 @@ class Person(Entry):
 
     contact_email: Optional[EmailStr]
     """In the case of multiple *verified* email identities, this email will be used as the primary contact."""
+
+    managers: Optional[List[PyObjectId]]
+    """A list of user IDs that can manage this person's items."""
 
     @validator("type", pre=True, always=True)
     def add_missing_type(cls, v):

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -339,6 +339,13 @@
           "title": "Contact Email",
           "type": "string",
           "format": "email"
+        },
+        "managers": {
+          "title": "Managers",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/pydatalab/schemas/sample.json
+++ b/pydatalab/schemas/sample.json
@@ -298,6 +298,13 @@
           "title": "Contact Email",
           "type": "string",
           "format": "email"
+        },
+        "managers": {
+          "title": "Managers",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -349,6 +349,13 @@
           "title": "Contact Email",
           "type": "string",
           "format": "email"
+        },
+        "managers": {
+          "title": "Managers",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       }
     },


### PR DESCRIPTION
This is a quick hack for one-to-many permissions for samples, e.g., one "manager" can see entries from any user that lists their ID as a manager. 

This should be iterated on to allow for proper group permission control, but think this is a useful start. Currently managers also have write access to the sample, but this can be discussed.