### PR TITLE
Remote filesystem scanning improvements

### DIFF
--- a/pydatalab/pydatalab/config.py
+++ b/pydatalab/pydatalab/config.py
@@ -51,6 +51,12 @@ class DeploymentMetadata(BaseModel):
         extra = "allow"
 
 
+class RemoteFilesystem(BaseModel):
+    name: str
+    hostname: Optional[str]
+    path: Path
+
+
 class ServerConfig(BaseSettings):
     """A model that provides settings for deploying the API."""
 
@@ -80,7 +86,7 @@ class ServerConfig(BaseSettings):
         RandomAlphabeticalRefcodeFactory, description="The class to use to generate refcodes."
     )
 
-    REMOTE_FILESYSTEMS: List[Dict[str, str]] = Field(
+    REMOTE_FILESYSTEMS: List[RemoteFilesystem] = Field(
         [],
         descripton="A list of dictionaries describing remote filesystems to be accessible from the server.",
     )
@@ -113,7 +119,7 @@ class ServerConfig(BaseSettings):
     def validate_cache_ages(cls, values):
         if values.get("REMOTE_CACHE_MIN_AGE") > values.get("REMOTE_CACHE_MAX_AGE"):
             raise RuntimeError(
-                f"The maximum cache age must be greater than the minimum cache age: {values}"
+                f"The maximum cache age must be greater than the minimum cache age: min {values.get('REMOTE_CACHE_MIN_AGE')=}, max {values.get('REMOTE_CACHE_MAX_AGE')=}"
             )
         return values
 
@@ -121,6 +127,7 @@ class ServerConfig(BaseSettings):
         env_prefix = "pydatalab_"
         extra = "allow"
         env_file_encoding = "utf-8"
+        validate_assignment = True
 
         @classmethod
         def customise_sources(

--- a/pydatalab/pydatalab/remote_filesystems.py
+++ b/pydatalab/pydatalab/remote_filesystems.py
@@ -96,10 +96,7 @@ def get_directory_structure(
         # then rebuild the cache.
         if (
             (not cached_dir_structure)
-            or (
-                invalidate_cache is not False
-                and cache_age > datetime.timedelta(minutes=CONFIG.REMOTE_CACHE_MAX_AGE)
-            )
+            or cache_age > datetime.timedelta(minutes=CONFIG.REMOTE_CACHE_MAX_AGE)
             or (
                 invalidate_cache
                 and cache_age > datetime.timedelta(minutes=CONFIG.REMOTE_CACHE_MIN_AGE)

--- a/pydatalab/pydatalab/routes/v0_1/__init__.py
+++ b/pydatalab/pydatalab/routes/v0_1/__init__.py
@@ -9,19 +9,18 @@ from .graphs import ENDPOINTS as graphs_endpoints
 from .healthcheck import ENDPOINTS as healthcheck_endpoints
 from .info import ENDPOINTS as info_endpoints
 from .items import ENDPOINTS as items_endpoints
-from .remotes import ENDPOINTS as remotes_endpoints
+from .remotes import remote
 
 ENDPOINTS: Dict[str, Callable] = {
     **blocks_endpoints,
     **items_endpoints,
     **files_endpoints,
-    **remotes_endpoints,
     **healthcheck_endpoints,
     **auth_endpoints,
     **graphs_endpoints,
     **info_endpoints,
 }
 
-BLUEPRINTS = [collection]
+BLUEPRINTS = [collection, remote]
 
 __all__ = ("ENDPOINTS", "BLUEPRINTS", "__api_version__")

--- a/pydatalab/tests/conftest.py
+++ b/pydatalab/tests/conftest.py
@@ -52,14 +52,21 @@ def client(real_mongo_client, monkeypatch_session):
 
     """
 
-    example_remote = {
-        "name": "example_data",
-        "hostname": None,
-        "path": Path(__file__).parent.joinpath("../example_data/"),
-    }
+    example_remotes = [
+        {
+            "name": "example_data",
+            "hostname": None,
+            "path": Path(__file__).parent.joinpath("../example_data/"),
+        },
+        {
+            "name": "example/data",
+            "hostname": None,
+            "path": Path(__file__).parent.joinpath("../example_data/"),
+        },
+    ]
     test_app_config = {
         "MONGO_URI": MONGO_URI,
-        "REMOTE_FILESYSTEMS": [example_remote],
+        "REMOTE_FILESYSTEMS": example_remotes,
         "TESTING": True,
     }
 

--- a/pydatalab/tests/routers/test_remotes.py
+++ b/pydatalab/tests/routers/test_remotes.py
@@ -1,0 +1,33 @@
+import pytest
+
+
+@pytest.mark.dependency()
+def test_directories_list(client):
+    response = client.get("/list-remote-directories")
+    assert response.json
+    toplevel = response.json["data"][0]
+    assert toplevel["type"] == "toplevel"
+    assert toplevel["status"] == "updated"
+
+    response = client.get("/remotes")
+    assert response.json
+    toplevel = response.json["data"][0]
+    assert toplevel["type"] == "toplevel"
+    assert toplevel["status"] == "cached"
+
+
+@pytest.mark.dependency(depends=["test_directories_list"])
+def test_single_directory(client):
+    response = client.get("/remotes/example_data?invalidate_cache=1")
+    assert response.json
+    toplevel = response.json["data"]
+    assert toplevel["type"] == "toplevel"
+    # even though `invalidate_cache` is set to 1, the directory is cached
+    # because it was just updated in the previous test and the min age is 1
+    assert toplevel["status"] == "cached"
+
+    response = client.get("/remotes/example/data?invalidate_cache=0")
+    assert response.json
+    toplevel = response.json["data"]
+    assert toplevel["type"] == "toplevel"
+    assert toplevel["status"] == "cached"

--- a/pydatalab/tests/test_config.py
+++ b/pydatalab/tests/test_config.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 from pydatalab.config import ServerConfig
+from pydatalab.main import create_app
 
 
 def test_default_settings():
@@ -22,3 +23,16 @@ def test_update_settings():
     assert config.NEW_KEY == new_settings["new_key"]
     assert config.SECRET_KEY
     assert Path(config.FILE_DIRECTORY).name == "files"
+
+
+def test_config_override():
+    app = create_app(
+        config_override={"REMOTE_FILESYSTEMS": [{"hostname": None, "path": "/", "name": "local"}]}
+    )
+    assert app.config["REMOTE_FILESYSTEMS"][0]["hostname"] is None
+    assert app.config["REMOTE_FILESYSTEMS"][0]["path"] == Path("/")
+
+    from pydatalab.config import CONFIG
+
+    assert CONFIG.REMOTE_FILESYSTEMS[0].hostname is None
+    assert CONFIG.REMOTE_FILESYSTEMS[0].path == Path("/")

--- a/webapp/src/components/TreeMenu.vue
+++ b/webapp/src/components/TreeMenu.vue
@@ -34,7 +34,7 @@
       </span>
     </div>
 
-    <div v-else-if="entry.type == 'error'" class="error-entry alert alert-warning">
+    <div v-else-if="entry.type == 'error'" class="error-entry alert alert-danger">
       <font-awesome-icon :icon="['fas', 'exclamation-circle']" class="mr-2" />
       <span>
         {{ entry.details }}

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -439,7 +439,7 @@ export function deleteFileFromSample(item_id, file_id) {
 export async function fetchRemoteTree(invalidate_cache) {
   var invalidate_cache_param = invalidate_cache ? "1" : "0";
   var url = new URL(
-    `${API_URL}/list-remote-directories/?invalidate_cache=${invalidate_cache_param}`
+    `${API_URL}/list-remote-directories?invalidate_cache=${invalidate_cache_param}`
   );
   console.log("fetchRemoteTree called!");
   store.commit("setRemoteDirectoryTreeIsLoading", true);


### PR DESCRIPTION
This PR adds a series of fixes for remote filesystems, in particular making them more robust to expected failures, e.g., host key changes or folders being removed.

Previously, an JSON unhandled error regarding a single remote would break the entire `/list-remote-directories` response, but now the error is nested within that remote (closes #428).

It adds an admin task `invoke admin.check-remotes` that can check the sync status of remotes individually using a new endpoint for listing a single remote (could be used in the future by the app for selective syncing).