### PR TITLE
Better sanitize inputs for plot cycle selector

### DIFF
--- a/pydatalab/pydatalab/apps/echem/utils.py
+++ b/pydatalab/pydatalab/apps/echem/utils.py
@@ -146,15 +146,26 @@ def filter_df_by_cycle_index(
     if cycle_list is None:
         return df
 
+    cycle_list = sorted(i for i in cycle_list if i > 0)
+
     if "half cycle" not in df.columns:
         if "cycle index" not in df.columns:
             raise ValueError(
                 "Input dataframe must have either 'half cycle' or 'cycle index' column"
             )
+
+        if len(cycle_list) == 1 and max(cycle_list) > df["cycle index"].max():
+            cycle_list[0] = df["cycle index"].max()
         return df[df["cycle index"].isin(i for i in cycle_list)]
 
     try:
-        half_cycles = [i for item in cycle_list for i in [(2 * int(item)) - 1, 2 * int(item)]]
+        if len(cycle_list) == 1 and 2 * max(cycle_list) > df["half cycle"].max():
+            cycle_list[0] = df["half cycle"].max() // 2
+        half_cycles = [
+            i
+            for item in cycle_list
+            for i in [max((2 * int(item)) - 1, df["half cycle"].min()), 2 * int(item)]
+        ]
     except ValueError as exc:
         raise ValueError(
             f"Unable to parse `cycle_list` as integers: {cycle_list}. Error: {exc}"

--- a/pydatalab/pydatalab/bokeh_plots.py
+++ b/pydatalab/pydatalab/bokeh_plots.py
@@ -441,8 +441,12 @@ def double_axes_echem_plot(
             else:
                 y = "dV/dQ (V/mA)"
 
+        # if filtering has removed all cycles, skip making the plot
+        if len(df) < 1:
+            raise RuntimeError("No data remaining to plot after filtering.")
+
         # trim the end of the colour cycle for visibility on a white background
-        color_space = np.linspace(0.3, 0.7, int(df["half cycle"].max()))  # type: ignore
+        color_space = np.linspace(0.3, 0.7, max(int(df["half cycle"].max()), 1))  # type: ignore
 
         for _, group in grouped_by_half_cycle:
             line = plot.line(

--- a/webapp/src/components/datablocks/CycleBlock.vue
+++ b/webapp/src/components/datablocks/CycleBlock.vue
@@ -15,6 +15,7 @@
         <input
           type="text"
           class="form-control"
+          placeholder="e.g., 1-5, 7, 9-10. Starts at 1."
           :class="{ 'is-invalid': cycle_num_error }"
           v-model="cyclesString"
           @keydown.enter="
@@ -209,10 +210,19 @@ export default {
       for (const section of cycle_string_sections) {
         let split_section = section.split("-");
         if (split_section.length == 1) {
+          let value = parseInt(split_section[0]);
+          if (value < 1) {
+            this.cycle_num_error = `Invalid input '${cyclesString}', cycle numbers start at 1.`;
+            return;
+          }
           all_cycles.push(parseInt(split_section[0]));
         } else {
           let upper_range = parseInt(split_section[1]);
           let lower_range = parseInt(split_section[0]);
+          if (lower_range < 1) {
+            this.cycle_num_error = `Invalid input '${cyclesString}', cycle numbers start at 1.`;
+            return;
+          }
           for (
             let j = Math.min(lower_range, upper_range);
             j <= Math.max(lower_range, upper_range);


### PR DESCRIPTION
Closes #420

Bit janky, but filters the cycle inputs better to prevent infinite loops of plot crashes when invalid cycles are provided. Now, 0 is explicitly banned in JS, and values beyond the maximum number of cycles should tap out and only plot the final cycle. 

Putting a range of values above the max value will still crash the plotter, but it will just fallback to the previous plot without raising a UI error (maybe need to consider this more).