### PR TITLE
Add subtitled intro video to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ in the Department of Chemistry at the University of Cambridge.
 
 ## Features
 
+### Introductory video
+
+https://github.com/the-grey-group/datalab/assets/7916000/0065cdd6-a5f0-4391-b192-0137fe208acc
+
+
 ### Server
 
 - A REST API for accessing data and analysis related to chemical samples,

--- a/README.md
+++ b/README.md
@@ -35,8 +35,10 @@ in the Department of Chemistry at the University of Cambridge.
 
 ### Introductory video
 
-https://github.com/the-grey-group/datalab/assets/7916000/0065cdd6-a5f0-4391-b192-0137fe208acc
-
+<div align="center">
+<video controls src="https://github.com/the-grey-group/datalab/assets/7916000/0065cdd6-a5f0-4391-b192-0137fe208acc">
+</video>
+</div>
 
 ### Server
 


### PR DESCRIPTION
Some magic going on to render this in the README, not sure how it looks in the docs but will have to fix after its deployed...