### PR TITLE
Adding limits on file uploads

### DIFF
--- a/pydatalab/pydatalab/config.py
+++ b/pydatalab/pydatalab/config.py
@@ -115,6 +115,15 @@ class ServerConfig(BaseSettings):
         None, description="A dictionary containing metadata to serve at `/info`."
     )
 
+    MAX_CONTENT_LENGTH: int = Field(
+        100 * 1000 * 1000,
+        description=r"""Direct mapping to the equivalent Flask setting. In practice, limits the file size that can be uploaded.
+Defaults to 100 GB to avoid filling the tmp directory of a server.
+
+Warning: this value will overwrite any other values passed to `FLASK_MAX_CONTENT_LENGTH` but is included here to clarify
+its importance when deploying a datalab instance.""",
+    )
+
     @root_validator
     def validate_cache_ages(cls, values):
         if values.get("REMOTE_CACHE_MIN_AGE") > values.get("REMOTE_CACHE_MAX_AGE"):

--- a/pydatalab/pydatalab/main.py
+++ b/pydatalab/pydatalab/main.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import pathlib
 from typing import Any, Dict
 
 from dotenv import dotenv_values
@@ -65,6 +66,9 @@ def create_app(config_override: Dict[str, Any] | None = None) -> Flask:
     LOGIN_MANAGER.init_app(app)
 
     pydatalab.mongo.create_default_indices()
+
+    if CONFIG.FILE_DIRECTORY is not None:
+        pathlib.Path(CONFIG.FILE_DIRECTORY).mkdir(parents=False, exist_ok=True)
 
     compress.init_app(app)
 

--- a/webapp/src/file_upload.js
+++ b/webapp/src/file_upload.js
@@ -13,7 +13,13 @@ import { API_URL } from "@/resources.js";
 
 export default function setupUppy(item_id, trigger_selector, reactive_file_list) {
   console.log("setupUppy called with: " + trigger_selector);
-  var uppy = new Uppy();
+  var uppy = new Uppy({
+    restrictions: {
+      // Somewhat arbitrary restrictions that prevent numbers that would break the server in one go -- the API should also refuse files when 'full'
+      maxTotalFileSize: 102400000000, // Set this UI restriction arbitrarily high at 100 GB for now --- this is the point at which I would be unsure if the upload could even complete
+      maxNumberOfFiles: 10000, // Similarly, a max of 10000 files in one upload as a single "File" entry feels reasonable, once we move to uploading folders etc.
+    },
+  });
   let headers = construct_headers();
   uppy
     .use(Dashboard, {

--- a/webapp/src/file_upload.js
+++ b/webapp/src/file_upload.js
@@ -8,7 +8,7 @@ import Webcam from "@uppy/webcam";
 import store from "@/store/index.js";
 import { construct_headers } from "@/server_fetch_utils.js";
 
-import { API_URL } from "@/resources.js";
+import { API_URL, UPPY_MAX_NUMBER_OF_FILES, UPPY_MAX_TOTAL_FILE_SIZE } from "@/resources.js";
 // file-upload loaded
 
 export default function setupUppy(item_id, trigger_selector, reactive_file_list) {
@@ -16,8 +16,8 @@ export default function setupUppy(item_id, trigger_selector, reactive_file_list)
   var uppy = new Uppy({
     restrictions: {
       // Somewhat arbitrary restrictions that prevent numbers that would break the server in one go -- the API should also refuse files when 'full'
-      maxTotalFileSize: 102400000000, // Set this UI restriction arbitrarily high at 100 GB for now --- this is the point at which I would be unsure if the upload could even complete
-      maxNumberOfFiles: 10000, // Similarly, a max of 10000 files in one upload as a single "File" entry feels reasonable, once we move to uploading folders etc.
+      maxTotalFileSize: UPPY_MAX_TOTAL_FILE_SIZE, // Set this UI restriction arbitrarily high at 100 GB for now --- this is the point at which I would be unsure if the upload could even complete
+      maxNumberOfFiles: UPPY_MAX_NUMBER_OF_FILES, // Similarly, a max of 10000 files in one upload as a single "File" entry feels reasonable, once we move to uploading folders etc.
     },
   });
   let headers = construct_headers();

--- a/webapp/src/resources.js
+++ b/webapp/src/resources.js
@@ -25,6 +25,15 @@ export const LOGO_URL = process.env.VUE_APP_LOGO_URL;
 export const HOMEPAGE_URL = process.env.VUE_APP_HOMEPAGE_URL;
 export const GRAVATAR_STYLE = "identicon";
 
+export const UPPY_MAX_TOTAL_FILE_SIZE =
+  Number(process.env.VUE_APP_UPPY_MAX_TOTAL_FILE_SIZE) != null
+    ? process.env.VUE_APP_UPPY_MAX_TOTAL_FILE_SIZE
+    : 102400000000;
+export const UPPY_MAX_NUMBER_OF_FILES =
+  Number(process.env.VUE_APP_UPPY_MAX_NUMBER_OF_FILES) != null
+    ? process.env.VUE_APP_UPPY_MAX_NUMBER_OF_FILES
+    : 10000;
+
 export const debounceTime = 250; // time after user stops typing before request is sent
 
 export const blockTypes = {


### PR DESCRIPTION
Closes #471 by adding file upload limits:

- [x] In the Uppy UI (100 GB in total and 10,000 files per upload)
    - [x] Both values configurable via env variables
- [x] In the API:
    - [x] At the level of Flask `MAX_CONTENT_SIZE` -- now this value is configurable to prevent massive files filling `/tmp` disks that could lead to instability on some systems -- think we are unaffected on the current deployment but will try to verify later
    - [x] At the level of remaining disk space in the configured mount point, e.g., whether there is enough space in `CONFIG.FILE_DIRECTORY` to actually store the thing. This is done with a pymongo lock that prevents new files being uploaded until previous files have been correctly stored in the fs and database.

Also this PR makes the files directory on app startup, if not present. Previously the routes themselves were making it on first upload, potentially with all required subdirectories. This can be a bit dangerous if the files directory is a dynamic mount point, as the wrong disk may silently be used if not previously mounted. We should probably make this more robust in the future, with better specification of e.g. remote data sources too for the files directory (S3 or other blob storage). May be worth abstracting this away with something like Maggma as a "store" controller but equally this may overcomplicate things for little gain for us.

Additionally, in the future/now if easily done, it would be nice to add better feedback on failures in the UI, i.e., overriding the default uppy error message with better messages directly from our API. This might be straightforward to do but tricky to test.