### PR TITLE
Add seperator as a fully-fledged cell constituent

### DIFF
--- a/pydatalab/pydatalab/models/cells.py
+++ b/pydatalab/pydatalab/models/cells.py
@@ -58,6 +58,8 @@ class Cell(Item):
 
     electrolyte: List[CellComponent] = Field([])
 
+    separator: List[CellComponent] = Field([])
+
     active_ion_charge: float = Field(1)
 
     @validator("characteristic_molar_mass", always=True, pre=True)
@@ -90,7 +92,7 @@ class Cell(Item):
         else:
             values["relationships"] = []
 
-        for component in ("positive_electrode", "negative_electrode", "electrolyte"):
+        for component in ("positive_electrode", "negative_electrode", "electrolyte", "separator"):
             for constituent in values.get(component, []):
                 if (
                     isinstance(constituent.item, EntryReference)

--- a/pydatalab/schemas/cell.json
+++ b/pydatalab/schemas/cell.json
@@ -169,6 +169,14 @@
         "$ref": "#/definitions/CellComponent"
       }
     },
+    "separator": {
+      "title": "Separator",
+      "default": [],
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/CellComponent"
+      }
+    },
     "active_ion_charge": {
       "title": "Active Ion Charge",
       "default": 1,

--- a/webapp/src/components/CellPreparationInformation.vue
+++ b/webapp/src/components/CellPreparationInformation.vue
@@ -25,6 +25,17 @@
     </div>
 
     <div class="form-group ml-5">
+      <label class="subheading cell-component-label mt-4 pb-1" for="electrolyte-table"
+        >Separator</label
+      >
+      <div class="card component-card">
+        <div class="card-body pt-2 pb-0 mb-0 pl-5">
+          <CompactConstituentTable id="separator-table" v-model="SeparatorConstituents" />
+        </div>
+      </div>
+    </div>
+
+    <div class="form-group ml-5">
       <label class="subheading cell-component-label mt-4 pb-1" for="neg-electrode-table"
         >Negative electrode</label
       >
@@ -70,6 +81,7 @@ export default {
     PosElectrodeConstituents: createComputedSetterForItemField("positive_electrode"),
     ElectrolyteConstituents: createComputedSetterForItemField("electrolyte"),
     NegElectrodeConstituents: createComputedSetterForItemField("negative_electrode"),
+    SeparatorConstituents: createComputedSetterForItemField("separator"),
     CellPreparationDescription: createComputedSetterForItemField("cell_preparation_description"),
   },
   watch: {
@@ -88,6 +100,12 @@ export default {
       deep: true,
     },
     NegElectrodeConstituents: {
+      handler() {
+        this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: false });
+      },
+      deep: true,
+    },
+    SeparatorConstituents: {
       handler() {
         this.$store.commit("setItemSaved", { item_id: this.item_id, isSaved: false });
       },


### PR DESCRIPTION
Closes #487. 

After discussion with @jdbocarsly, probably the advice is to include the separator as a component of the electrolyte. This PR will need to be updated to add this as part of the documentation in the UI (simple tooltip somewhere).