### PR TITLE
CI build optimisations

### DIFF
--- a/.docker/server_dockerfile
+++ b/.docker/server_dockerfile
@@ -6,13 +6,9 @@ RUN apt update && apt install -y tree && apt clean
 
 # Install the older version of mdbtools (0.7.1) until https://github.com/echemdata/galvani/issues/89 is resolved
 WORKDIR /opt
-RUN git clone https://github.com/mdbtools/mdbtools --depth 1 --branch 0.7.1
-WORKDIR /opt/mdbtools
-RUN autoreconf -i -f
-RUN ./configure --disable-man
-RUN make -j 4
-RUN make install
-RUN ldconfig
+RUN curl -L https://github.com/mdbtools/mdbtools/archive/refs/tags/0.7.1.zip > 0.7.1.zip && unzip -d /opt/mdbtools 0.7.1.zip && rm 0.7.1.zip
+WORKDIR /opt/mdbtools/mdbtools-0.7.1
+RUN autoreconf -i -f &&  ./configure --disable-man && make -j 4 && make install && ldconfig
 
 
 FROM base as app

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,15 +118,22 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Debugging
+        run: |
+          docker image ls
+
       - name: Build the Docker images
         uses: docker/bake-action@v4
         with:
           files: docker-compose.yml
           load: true
-          push: false
           set: |
             *.cache-from=type=gha,scope=cached-stage
             *.cache-to=type=gha,scope=cached-stage,mode=max
+
+      - name: Debugging
+        run: |
+          docker image ls
 
       - name: Start Docker images
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,7 +134,7 @@ jobs:
           docker network create nginx
           # Set API runtime config for testing mode to disable auth
           echo "PYDATALAB_TESTING=true" >> pydatalab/.env
-          docker compose --env-file pydatalab/.env --profile prod up -d --wait --no-build
+          docker compose --env-file pydatalab/.env --profile prod up -d --wait
 
       - name: Run end-to-end tests
         working-directory: ./webapp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,17 +139,3 @@ jobs:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
         run: |
           yarn test:e2e  --headless --url http://localhost:8081 --record
-
-      - name: Archive video from cypress
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Cypress video
-          path: /home/runner/work/datalabvue/datalabvue/webapp/cypress/videos/*.cy.js.mp4
-
-      - name: Archive any failure screenshots from Cypress
-        if: failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: Cypress screenshots
-          path: /home/runner/work/datalabvue/datalabvue/webapp/cypress/screenshots/*/*.png

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,8 +114,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build the Docker images
-        uses: docker/bake-action@v2.3.0
+        uses: docker/bake-action@v4
         with:
           files: docker-compose.yml
           load: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,8 +137,9 @@ jobs:
           docker compose --env-file pydatalab/.env --profile prod up -d --wait
 
       - name: Run end-to-end tests
-        working-directory: ./webapp
+        uses: cypress-io/github-action@v6
+        with:
+          config: baseUrl=http://localhost:8081
+          working-directory: ./webapp
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
-        run: |
-          yarn test:e2e  --headless --url http://localhost:8081 --record

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,9 +86,8 @@ jobs:
         uses: codecov/codecov-action@v3
 
   webapp:
-    name: Test the webapp
+    name: Test the app build
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
 
@@ -109,16 +108,30 @@ jobs:
         working-directory: ./webapp
         run: yarn build
 
+
+  e2e:
+    name: Run e2e tests across app and API
+    runs-on: ubuntu-latest
+
+    steps:
       - name: Build the Docker images
-        run: |
-          echo "PYDATALAB_TESTING=true" >> pydatalab/.env
-          docker compose --profile prod build
+        uses: docker/bake-action@v2.3.0
+        with:
+          files: docker-compose.yml
+          load: true
+          push: false
+          targets: prod
+          set: |
+            *.cache-from=type=gha,scope=cached-stage
+            *.cache-to=type=gha,scope=cached-stage,mode=max
 
       - name: Start Docker images
         run: |
           # Create a named docker network that all containers attach to
           docker network create nginx
-          docker compose --profile prod up -d --wait --no-build
+          # Set API runtime config for testing mode to disable auth
+          echo "PYDATALAB_TESTING=true" >> pydatalab/.env
+          docker compose --env-file pydatalab/.env --profile prod up -d --wait --no-build
 
       - name: Run end-to-end tests
         working-directory: ./webapp

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,6 @@ jobs:
         working-directory: ./webapp
         run: yarn build
 
-
   e2e:
     name: Run e2e tests across app and API
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,6 @@ jobs:
           files: docker-compose.yml
           load: true
           push: false
-          targets: prod
           set: |
             *.cache-from=type=gha,scope=cached-stage
             *.cache-to=type=gha,scope=cached-stage,mode=max

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - "8081:8081"
     networks:
       - nginx
-      - default
 
   api:
     profiles: ["prod"]


### PR DESCRIPTION
This should speed up the CI a little bit by using `docker buildx bake` to do cached builds, plus the cypress GH action to avoid needing to install it.