### PR TITLE
Make sure cypress cloud runs are recorded

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,5 +148,6 @@ jobs:
         with:
           config: baseUrl=http://localhost:8081
           working-directory: ./webapp
+          record: true
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}


### PR DESCRIPTION
Since the last couple of PRs runs have not been uploaded to Cypress cloud. This PR fixes that.

Also its a test to see if the e2e tests really do work in the current state, or whether #484 is really just broken...