### PR TITLE
Check and warn for missing secrets in server startup logs

### DIFF
--- a/pydatalab/pydatalab/config.py
+++ b/pydatalab/pydatalab/config.py
@@ -185,26 +185,12 @@ its importance when deploying a datalab instance.""",
     def validate_identifier_prefix(cls, v, values):
         """Make sure that the identifier prefix is set and is valid, raising clear error messages if not.
 
-        If in testing mode, then set the prefix to test too.
+        If in testing mode, then set the prefix to 'test' too.
+        The app startup will test for this value and should also warn aggressively that this is unset.
 
         """
 
-        if values.get("TESTING"):
-            return "test"
-
-        if v is None:
-            import warnings
-
-            warning_msg = (
-                "You should configure an identifier prefix for this deployment. "
-                "You should attempt to make it unique to your deployment or group. "
-                "In the future these will be optionally globally validated versus all deployments for uniqueness. "
-                "For now the value of `test` will be used."
-            )
-
-            warnings.warn(warning_msg)
-            logging.warning(warning_msg)
-
+        if values.get("TESTING") or v is None:
             return "test"
 
         if len(v) > 12:

--- a/pydatalab/pydatalab/logger.py
+++ b/pydatalab/pydatalab/logger.py
@@ -14,7 +14,7 @@ class AnsiColorHandler(logging.StreamHandler):
     LOGLEVEL_COLORS = {
         logging.DEBUG: "36m",
         logging.INFO: "32m",
-        logging.WARNING: "33m",
+        logging.WARNING: "103;30m",
         logging.ERROR: "1;91m",
         logging.CRITICAL: "101;30m",
     }

--- a/pydatalab/tests/test_config.py
+++ b/pydatalab/tests/test_config.py
@@ -41,10 +41,6 @@ def test_config_override():
 
 
 def test_validators():
-    # check that prefix must be set
-    with pytest.warns():
-        _ = ServerConfig(IDENTIFIER_PREFIX=None)
-
     # check bad prefix
     with pytest.raises(RuntimeError):
         _ = ServerConfig(IDENTIFIER_PREFIX="this prefix is way way too long")


### PR DESCRIPTION
This PR simply loops over some common secrets and warns on startup if they are not present. At some point we could allow blocks to define these secrets dynamically rather than enumerating in main, but this should help with debugging of deployments.