### PR TITLE
Fix `y_options` bug when plotting 1D Raman

### DIFF
--- a/pydatalab/pydatalab/apps/raman/blocks.py
+++ b/pydatalab/pydatalab/apps/raman/blocks.py
@@ -165,7 +165,7 @@ class RamanBlock(DataBlock):
                     self.accepted_file_extensions,
                     ext,
                 )
-            pattern_dfs, y_options, _ = self.load(file_info["location"])
+            pattern_dfs, _, y_options = self.load(file_info["location"])
             pattern_dfs = [pattern_dfs]
 
         if pattern_dfs:


### PR DESCRIPTION
This is the bug I spotted @elbee99, think I introduced it when reviewing your last PR. Thankfully its a simple fix!