### PR TITLE
Add UI for adding an existing item to an existing collection

### DIFF
--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -222,7 +222,20 @@ def collections_lookup() -> Dict:
     }
 
 
-def _check_collections(sample_dict):
+def _check_collections(sample_dict: dict) -> list[dict[str, str]]:
+    """Loop through the provided collection metadata for the sample and
+    return the list of references to store (i.e., just the `immutable_id`
+    of the collection).
+
+    Raises:
+        ValueError: if any of the linked collections cannot be found in
+        the database.
+
+    Returns:
+        A list of dictionaries with singular key `immutable_id` returning
+        the database ID of the collection.
+
+    """
     if sample_dict.get("collections", []):
         for ind, c in enumerate(sample_dict.get("collections", [])):
             query = {}

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -32,7 +32,7 @@
           <div class="form-group col-md-3">
             <label id="collections" class="mr-2">Collections</label>
             <div>
-              <CollectionList aria-labelledby="collections" :collections="Collections" />
+              <CollectionSelect aria-labelledby="collections" multiple v-model="Collections" />
             </div>
           </div>
         </div>
@@ -115,7 +115,7 @@ import CellPreparationInformation from "@/components/CellPreparationInformation"
 import TableOfContents from "@/components/TableOfContents";
 import ItemRelationshipVisualization from "@/components/ItemRelationshipVisualization";
 import FormattedRefcode from "@/components/FormattedRefcode";
-import CollectionList from "@/components/CollectionList";
+import CollectionSelect from "@/components/CollectionSelect";
 import Creators from "@/components/Creators";
 import { cellFormats } from "@/resources.js";
 
@@ -154,7 +154,7 @@ export default {
     TableOfContents,
     ItemRelationshipVisualization,
     FormattedRefcode,
-    CollectionList,
+    CollectionSelect,
     Creators,
   },
 };

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -16,7 +16,9 @@
         <div class="form-row">
           <div class="form-group col-md-3 col-sm-2 col-6 pr-2">
             <label for="refcode">Refcode</label>
-            <FormattedRefcode :refcode="Refcode" />
+            <div id="refcode">
+              <FormattedRefcode :refcode="Refcode" />
+            </div>
           </div>
           <div class="form-group col-md-3 col-sm-3 col-6 pb-3 pr-2">
             <label id="creators">Creators</label>

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -24,11 +24,8 @@
               <Creators aria-labelledby="creators" :creators="ItemCreators" :size="36" />
             </div>
           </div>
-          <div class="form-group col-md-6 col-sm-7 pr-2">
-            <label id="collections">Collections</label>
-            <div>
-              <CollectionSelect aria-labelledby="collections" multiple v-model="Collections" />
-            </div>
+          <div class="col-md-6 col-sm-7 pr-2">
+            <ToggleableCollectionFormGroup v-model="Collections" />
           </div>
         </div>
         <div class="form-row">
@@ -110,7 +107,7 @@ import CellPreparationInformation from "@/components/CellPreparationInformation"
 import TableOfContents from "@/components/TableOfContents";
 import ItemRelationshipVisualization from "@/components/ItemRelationshipVisualization";
 import FormattedRefcode from "@/components/FormattedRefcode";
-import CollectionSelect from "@/components/CollectionSelect";
+import ToggleableCollectionFormGroup from "@/components/ToggleableCollectionFormGroup";
 import Creators from "@/components/Creators";
 import { cellFormats } from "@/resources.js";
 
@@ -149,7 +146,7 @@ export default {
     TableOfContents,
     ItemRelationshipVisualization,
     FormattedRefcode,
-    CollectionSelect,
+    ToggleableCollectionFormGroup,
     Creators,
   },
 };

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -1,44 +1,39 @@
 <template>
-  <div class="container">
+  <div class="container-lg">
     <!-- Sample information -->
     <div class="row">
-      <div class="col">
+      <div class="col-md-8">
         <div id="sample-information" class="form-row">
-          <div class="form-group col-md-5">
+          <div class="form-group col-sm-8">
             <label for="name" class="mr-2">Name</label>
             <input id="name" class="form-control" v-model="Name" />
           </div>
-          <div class="form-group col-md-3">
+          <div class="form-group col-sm-4">
             <label for="date" class="mr-2">Date Created</label>
-            <input
-              type="datetime-local"
-              v-model="DateCreated"
-              class="form-control"
-              style="max-width: 250px"
-            />
+            <input type="datetime-local" v-model="DateCreated" class="form-control" />
           </div>
         </div>
         <div class="form-row">
-          <div class="form-group col-md-2">
-            <label for="refcode" class="mr-2">Refcode</label>
+          <div class="form-group col-md-3 col-sm-2 col-6 pr-2">
+            <label for="refcode">Refcode</label>
             <FormattedRefcode :refcode="Refcode" />
           </div>
-          <div class="col-md-2 pb-3">
-            <label id="creators" class="mr-2">Creators</label>
+          <div class="form-group col-md-3 col-sm-3 col-6 pb-3 pr-2">
+            <label id="creators">Creators</label>
             <div class="mx-auto">
               <Creators aria-labelledby="creators" :creators="ItemCreators" :size="36" />
             </div>
           </div>
-          <div class="form-group col-md-3">
-            <label id="collections" class="mr-2">Collections</label>
+          <div class="form-group col-md-6 col-sm-7 pr-2">
+            <label id="collections">Collections</label>
             <div>
               <CollectionSelect aria-labelledby="collections" multiple v-model="Collections" />
             </div>
           </div>
         </div>
         <div class="form-row">
-          <div class="form-group col-md-2">
-            <label for="cell-format-dropdown" class="mr-2">Cell format</label>
+          <div class="form-group col-sm-4 pr-2">
+            <label for="cell-format-dropdown">Cell format</label>
             <select id="cell-format-dropdown" v-model="CellFormat" class="form-control">
               <option
                 v-for="(description, key) in availableCellFormats"
@@ -49,7 +44,7 @@
               </option>
             </select>
           </div>
-          <div class="form-group col-md-6 ml-3">
+          <div class="form-group col-sm-8">
             <label for="cell-format-description">Cell format description</label>
             <input
               id="cell-format-description"
@@ -61,7 +56,7 @@
         </div>
 
         <div class="form-row py-4">
-          <div class="form-group col-md-3">
+          <div class="form-group col-lg-3 col-md-4 pr-3">
             <label for="characteristic-mass">Active mass (mg)</label>
             <input
               id="characteristic-mass"
@@ -71,11 +66,11 @@
               :class="{ 'red-border': isNaN(CharacteristicMass) }"
             />
           </div>
-          <div class="form-group col-md-4 ml-3">
-            <label for="chemform">Active material formula</label>
+          <div class="form-group col-lg-4 col-md-4 pr-3">
+            <label for="chemform">Active formula</label>
             <ChemFormulaInput id="chemform" v-model="ChemForm" />
           </div>
-          <div class="form-group col-md-3 ml-3">
+          <div class="form-group col-lg-3 col-md-4">
             <label for="characteristic-molar-mass">Molar mass</label>
             <input
               id="characteristic-molar-mass"
@@ -88,7 +83,7 @@
         </div>
         <div class="row">
           <div class="col">
-            <label id="description-label" class="mr-2">Description</label>
+            <label id="description-label">Description</label>
             <TinyMceInline
               aria-labelledby="description-label"
               v-model="SampleDescription"

--- a/webapp/src/components/CollectionList.vue
+++ b/webapp/src/components/CollectionList.vue
@@ -1,11 +1,11 @@
 <template>
-  <span v-for="collection in collections" :key="collection.collection_id">
+  <div class="collection-list" v-for="collection in collections" :key="collection.collection_id">
     <FormattedCollectionName
       :collection_id="collection.collection_id"
       enableClick
       enableModifiedClick
     />
-  </span>
+  </div>
 </template>
 
 <script>

--- a/webapp/src/components/CollectionSelect.vue
+++ b/webapp/src/components/CollectionSelect.vue
@@ -9,7 +9,7 @@
   >
     <template #no-options="{ searching }">
       <span v-if="searching"> Sorry, no matches found. </span>
-      <span v-else class="empty-search"> Type a search term... </span>
+      <span v-else class="empty-search"> Search for a collection... </span>
     </template>
     <template v-slot:option="{ collection_id, title }">
       <FormattedCollectionName
@@ -19,10 +19,9 @@
         :maxLength="formattedItemNameMaxLength"
       />
     </template>
-    <template v-slot:selected-option="{ collection_id, title }">
+    <template v-slot:selected-option="{ collection_id }">
       <FormattedCollectionName
         :collection_id="collection_id"
-        :title="title"
         enableModifiedClick
         :maxLength="formattedItemNameMaxLength"
       />

--- a/webapp/src/components/CollectionSelect.vue
+++ b/webapp/src/components/CollectionSelect.vue
@@ -2,8 +2,8 @@
   <vSelect
     v-model="value"
     :options="collections"
+    multiple
     @search="debouncedAsyncSearch"
-    label="name"
     :filterable="false"
     ref="selectComponent"
   >
@@ -73,6 +73,12 @@ export default {
       this.debounceTimeout = setTimeout(async () => {
         await searchCollections(query, 100)
           .then((collections) => {
+            // check if the searched collections are already listed in the value
+            // if so, remove it from the list of options
+            if (this.value) {
+              const valueIds = this.value.map((item) => item.collection_id);
+              collections = collections.filter((item) => !valueIds.includes(item.collection_id));
+            }
             this.collections = collections;
           })
           .catch((error) => {

--- a/webapp/src/components/CollectionTable.vue
+++ b/webapp/src/components/CollectionTable.vue
@@ -4,10 +4,9 @@
   </div>
   <table class="table table-hover table-sm" data-testid="collection-table">
     <thead>
-      <tr align="center">
+      <tr>
         <th scope="col">ID</th>
         <th scope="col">Title</th>
-        <th scope="col"># of items</th>
         <th scope="col">Creators</th>
         <th scope="col"></th>
       </tr>
@@ -29,7 +28,6 @@
           />
         </td>
         <td align="left">{{ collection.title }}</td>
-        <td align="right">{{ collection.num_items || 0 }}</td>
         <td align="center"><Creators :creators="collection.creators" /></td>
         <td align="right">
           <button

--- a/webapp/src/components/FancyCollectionSampleTable.vue
+++ b/webapp/src/components/FancyCollectionSampleTable.vue
@@ -21,14 +21,12 @@
     :items="samples"
     :loading="!sampleTableIsReady"
     :no-hover="true"
-    :checkbox-column-width="40"
     :expand-column-width="40"
     :search-value="searchValue"
     table-class-name="customize-table"
     header-class-name="customize-table-header"
     buttons-pagination
     @click-row="goToEditPage"
-    v-model:items-selected="itemsSelected"
   >
     <template #empty-message>Collection is empty.</template>
 

--- a/webapp/src/components/FancyCollectionSampleTable.vue
+++ b/webapp/src/components/FancyCollectionSampleTable.vue
@@ -4,13 +4,6 @@
   </div>
 
   <div class="form-inline mb-2 ml-auto mt-2">
-    <button
-      class="btn btn-default ml-auto mr-2"
-      :disabled="!Boolean(itemsSelected.length)"
-      @click="deleteSelectedItems"
-    >
-      Remove selected...
-    </button>
     <div class="form-group">
       <label for="sample-table-search" class="sr-only">Search items</label>
       <input
@@ -18,7 +11,7 @@
         type="text"
         class="form-control"
         v-model="searchValue"
-        placeholder="search"
+        placeholder="Search within collection"
       />
     </div>
   </div>

--- a/webapp/src/components/ItemRelationshipVisualization.vue
+++ b/webapp/src/components/ItemRelationshipVisualization.vue
@@ -1,5 +1,5 @@
 <template>
-  <label class="mr-2">Relationships</label>
+  <label class="pr-2">Relationships</label>
   <div>
     <ItemGraph
       :graphData="graphData"

--- a/webapp/src/components/SampleInformation.vue
+++ b/webapp/src/components/SampleInformation.vue
@@ -33,10 +33,10 @@
               <Creators aria-labelledby="creators" :creators="ItemCreators" :size="36" />
             </div>
           </div>
-          <div class="form-group col-md-3">
+          <div class="form-group col-md">
             <label id="collections" class="mr-2">Collections</label>
             <div>
-              <CollectionList aria-labelledby="collections" :collections="Collections" />
+              <CollectionSelect aria-labelledby="collections" multiple v-model="Collections" />
             </div>
           </div>
         </div>
@@ -65,7 +65,7 @@
 import { createComputedSetterForItemField } from "@/field_utils.js";
 import ChemFormulaInput from "@/components/ChemFormulaInput";
 import FormattedRefcode from "@/components/FormattedRefcode";
-import CollectionList from "@/components/CollectionList";
+import CollectionSelect from "@/components/CollectionSelect";
 import TinyMceInline from "@/components/TinyMceInline";
 import SynthesisInformation from "@/components/SynthesisInformation";
 import TableOfContents from "@/components/TableOfContents";
@@ -103,7 +103,7 @@ export default {
     TableOfContents,
     ItemRelationshipVisualization,
     FormattedRefcode,
-    CollectionList,
+    CollectionSelect,
     Creators,
   },
 };

--- a/webapp/src/components/SampleInformation.vue
+++ b/webapp/src/components/SampleInformation.vue
@@ -23,20 +23,38 @@
           </div>
         </div>
         <div class="form-row">
-          <div class="form-group col-md-2">
+          <div class="form-group col-md-3 col-sm-2">
             <label for="refcode" class="mr-2">Refcode</label>
             <FormattedRefcode :refcode="Refcode" />
           </div>
-          <div class="col-md-2 pb-3">
+          <div class="form-group col-md-3 col-sm-3 pb-3">
             <label id="creators" class="mr-2">Creators</label>
             <div class="mx-auto">
               <Creators aria-labelledby="creators" :creators="ItemCreators" :size="36" />
             </div>
           </div>
-          <div class="form-group col-md">
-            <label id="collections" class="mr-2">Collections</label>
+          <div class="form-group col-md-6 col-sm-7">
+            <label id="collections" class="mr-2">
+              Collections
+              <span
+                class="clickable text-italic"
+                :class="{ 'text-heavy': isEditingCollections }"
+                @click="isEditingCollections = !isEditingCollections"
+                >[edit]</span
+              >
+            </label>
             <div>
-              <CollectionSelect aria-labelledby="collections" multiple v-model="Collections" />
+              <CollectionList
+                v-if="!isEditingCollections"
+                aria-labelledby="collections"
+                :collections="Collections"
+              />
+              <CollectionSelect
+                v-show="isEditingCollections"
+                aria-labelledby="collections"
+                multiple
+                v-model="Collections"
+              />
             </div>
           </div>
         </div>
@@ -66,6 +84,7 @@ import { createComputedSetterForItemField } from "@/field_utils.js";
 import ChemFormulaInput from "@/components/ChemFormulaInput";
 import FormattedRefcode from "@/components/FormattedRefcode";
 import CollectionSelect from "@/components/CollectionSelect";
+import CollectionList from "@/components/CollectionList";
 import TinyMceInline from "@/components/TinyMceInline";
 import SynthesisInformation from "@/components/SynthesisInformation";
 import TableOfContents from "@/components/TableOfContents";
@@ -79,6 +98,7 @@ export default {
   },
   data() {
     return {
+      isEditingCollections: false,
       tableOfContentsSections: [
         { title: "Sample Information", targetID: "sample-information" },
         { title: "Table of Contents", targetID: "table-of-contents" },
@@ -104,7 +124,22 @@ export default {
     ItemRelationshipVisualization,
     FormattedRefcode,
     CollectionSelect,
+    CollectionList,
     Creators,
   },
 };
 </script>
+
+<style scoped>
+.clickable {
+  cursor: pointer;
+}
+
+.text-italic {
+  opacity: 0.7;
+}
+
+.text-heavy {
+  font-weight: 600;
+}
+</style>

--- a/webapp/src/components/SampleInformation.vue
+++ b/webapp/src/components/SampleInformation.vue
@@ -1,40 +1,37 @@
 <template>
-  <div class="container">
+  <div class="container-lg">
     <!-- Sample information -->
     <div class="row">
       <div class="col">
         <div id="sample-information" class="form-row">
-          <div class="form-group col-md-4">
-            <label for="name" class="mr-2">Name</label>
+          <div class="form-group col-sm-4 pr-2">
+            <label for="name">Name</label>
             <input id="name" class="form-control" v-model="Name" />
           </div>
-          <div class="form-group col-md-4">
-            <label for="chemform" class="mr-2">Chemical formula</label>
+          <div class="form-group col-sm-4 col-6 pr-2">
+            <label for="chemform">Chemical formula</label>
             <ChemFormulaInput id="chemform" v-model="ChemForm" />
           </div>
-          <div class="form-group col-md-4">
-            <label for="date" class="mr-2">Date Created</label>
-            <input
-              type="datetime-local"
-              v-model="DateCreated"
-              class="form-control"
-              style="max-width: 250px"
-            />
+          <div class="form-group col-sm-4 col-6">
+            <label for="date">Date Created</label>
+            <input type="datetime-local" v-model="DateCreated" class="form-control" />
           </div>
         </div>
         <div class="form-row">
-          <div class="form-group col-md-3 col-sm-2">
-            <label for="refcode" class="mr-2">Refcode</label>
-            <FormattedRefcode :refcode="Refcode" />
+          <div class="form-group col-md-3 col-sm-2 col-6">
+            <label for="refcode">Refcode</label>
+            <div id="refcode">
+              <FormattedRefcode :refcode="Refcode" />
+            </div>
           </div>
-          <div class="form-group col-md-3 col-sm-3 pb-3">
-            <label id="creators" class="mr-2">Creators</label>
+          <div class="form-group col-md-3 col-sm-3 col-6 pb-3">
+            <label id="creators">Creators</label>
             <div class="mx-auto">
               <Creators aria-labelledby="creators" :creators="ItemCreators" :size="36" />
             </div>
           </div>
-          <div class="form-group col-md-6 col-sm-7">
-            <label id="collections" class="mr-2">
+          <div class="form-group col-md-6 col-sm-7 pr-2">
+            <label id="collections">
               Collections
               <span
                 class="clickable text-italic"
@@ -58,9 +55,9 @@
             </div>
           </div>
         </div>
-        <div class="row">
+        <div class="form-row">
           <div class="col">
-            <label id="description-label" class="mr-2">Description</label>
+            <label id="description-label">Description</label>
             <TinyMceInline
               aria-labelledby="description-label"
               v-model="SampleDescription"

--- a/webapp/src/components/SampleInformation.vue
+++ b/webapp/src/components/SampleInformation.vue
@@ -30,29 +30,8 @@
               <Creators aria-labelledby="creators" :creators="ItemCreators" :size="36" />
             </div>
           </div>
-          <div class="form-group col-md-6 col-sm-7 pr-2">
-            <label id="collections">
-              Collections
-              <span
-                class="clickable text-italic"
-                :class="{ 'text-heavy': isEditingCollections }"
-                @click="isEditingCollections = !isEditingCollections"
-                >[edit]</span
-              >
-            </label>
-            <div>
-              <CollectionList
-                v-if="!isEditingCollections"
-                aria-labelledby="collections"
-                :collections="Collections"
-              />
-              <CollectionSelect
-                v-show="isEditingCollections"
-                aria-labelledby="collections"
-                multiple
-                v-model="Collections"
-              />
-            </div>
+          <div class="col-md-6 col-sm-7 pr-2">
+            <ToggleableCollectionFormGroup v-model="Collections" />
           </div>
         </div>
         <div class="form-row">
@@ -80,8 +59,7 @@
 import { createComputedSetterForItemField } from "@/field_utils.js";
 import ChemFormulaInput from "@/components/ChemFormulaInput";
 import FormattedRefcode from "@/components/FormattedRefcode";
-import CollectionSelect from "@/components/CollectionSelect";
-import CollectionList from "@/components/CollectionList";
+import ToggleableCollectionFormGroup from "@/components/ToggleableCollectionFormGroup";
 import TinyMceInline from "@/components/TinyMceInline";
 import SynthesisInformation from "@/components/SynthesisInformation";
 import TableOfContents from "@/components/TableOfContents";
@@ -95,7 +73,6 @@ export default {
   },
   data() {
     return {
-      isEditingCollections: false,
       tableOfContentsSections: [
         { title: "Sample Information", targetID: "sample-information" },
         { title: "Table of Contents", targetID: "table-of-contents" },
@@ -120,23 +97,8 @@ export default {
     TableOfContents,
     ItemRelationshipVisualization,
     FormattedRefcode,
-    CollectionSelect,
-    CollectionList,
+    ToggleableCollectionFormGroup,
     Creators,
   },
 };
 </script>
-
-<style scoped>
-.clickable {
-  cursor: pointer;
-}
-
-.text-italic {
-  opacity: 0.7;
-}
-
-.text-heavy {
-  font-weight: 600;
-}
-</style>

--- a/webapp/src/components/ToggleableCollectionFormGroup.vue
+++ b/webapp/src/components/ToggleableCollectionFormGroup.vue
@@ -1,0 +1,71 @@
+<template>
+  <div class="form-group">
+    <label id="collections">
+      Collections
+      <span
+        class="clickable text-italic"
+        :class="{ 'text-heavy': isEditingCollections }"
+        @click="isEditingCollections = !isEditingCollections"
+        >[edit]</span
+      >
+    </label>
+    <div>
+      <CollectionList
+        v-if="!isEditingCollections"
+        aria-labelledby="collections"
+        :collections="value"
+      />
+      <CollectionSelect
+        v-if="isEditingCollections"
+        aria-labelledby="collections"
+        multiple
+        v-model="value"
+      />
+    </div>
+  </div>
+</template>
+
+<script>
+import CollectionSelect from "@/components/CollectionSelect";
+import CollectionList from "@/components/CollectionList";
+
+export default {
+  props: {
+    modelValue: {},
+  },
+  data() {
+    return {
+      isEditingCollections: false,
+    };
+  },
+  computed: {
+    // computed setter to pass v-model through  component:
+    value: {
+      get() {
+        return this.modelValue;
+      },
+      set(newValue) {
+        this.$emit("update:modelValue", newValue);
+      },
+    },
+  },
+  components: {
+    CollectionSelect,
+    CollectionList,
+  },
+};
+</script>
+
+<style scoped>
+.clickable {
+  cursor: pointer;
+}
+
+.text-italic {
+  opacity: 0.7;
+}
+
+.text-heavy {
+  font-weight: 600;
+}
+</style>

--- a/webapp/src/components/ToggleableCollectionFormGroup.vue
+++ b/webapp/src/components/ToggleableCollectionFormGroup.vue
@@ -2,18 +2,20 @@
   <div class="form-group">
     <label id="collections">
       Collections
-      <span
-        class="clickable text-italic"
-        :class="{ 'text-heavy': isEditingCollections }"
+      <font-awesome-icon
+        class="clickable"
+        icon="pen"
+        size="xs"
+        :fade="isEditingCollections"
         @click="isEditingCollections = !isEditingCollections"
-        >[edit]</span
-      >
+      />
     </label>
-    <div>
+    <div style="height: 2em">
       <CollectionList
         v-if="!isEditingCollections"
         aria-labelledby="collections"
         :collections="value"
+        style="padding-top: 0.5rem"
       />
       <CollectionSelect
         v-if="isEditingCollections"
@@ -63,6 +65,9 @@ export default {
 
 .text-italic {
   opacity: 0.7;
+}
+.clickable {
+  color: grey;
 }
 
 .text-heavy {

--- a/webapp/src/main.js
+++ b/webapp/src/main.js
@@ -11,6 +11,7 @@ import router from "./router";
 import { library } from "@fortawesome/fontawesome-svg-core";
 import {
   faSave,
+  faPen,
   faCode,
   faEnvelope,
   faCog,
@@ -44,6 +45,7 @@ import { faGithub, faOrcid } from "@fortawesome/free-brands-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/vue-fontawesome";
 library.add(
   faSave,
+  faPen,
   faCode,
   faEnvelope,
   faCog,

--- a/webapp/src/resources.js
+++ b/webapp/src/resources.js
@@ -82,7 +82,7 @@ export const itemTypes = {
     itemInformationComponent: CollectionInformation,
     navbarColor: "#563D7c",
     navbarName: "Collection",
-    lightColor: "#B38FEA",
+    lightColor: "#e7dcf8",
     labelColor: "#845dbf",
     display: "collection",
   },


### PR DESCRIPTION
This PR adds a `CollectionSelect` to the sample and cell pages that can be used put items into existing collections. This UI was missing from #404 and closes #423. This required a minor specialisation of the existing collections UI to avoid duplicate listed entries in cases where a sample is already in a collection.

Still missing is a way to add items to a collection from the collections page, as this requires more plumbing on the API side.