### PR TITLE
[WIP] Add routes to add an item to a collection from the collections page

### DIFF
--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -222,7 +222,20 @@ def collections_lookup() -> Dict:
     }
 
 
-def _check_collections(sample_dict):
+def _check_collections(sample_dict: dict) -> list[dict[str, str]]:
+    """Loop through the provided collection metadata for the sample and
+    return the list of references to store (i.e., just the `immutable_id`
+    of the collection).
+
+    Raises:
+        ValueError: if any of the linked collections cannot be found in
+        the database.
+
+    Returns:
+        A list of dictionaries with singular key `immutable_id` returning
+        the database ID of the collection.
+
+    """
     if sample_dict.get("collections", []):
         for ind, c in enumerate(sample_dict.get("collections", [])):
             query = {}

--- a/webapp/src/components/CellInformation.vue
+++ b/webapp/src/components/CellInformation.vue
@@ -32,7 +32,7 @@
           <div class="form-group col-md-3">
             <label id="collections" class="mr-2">Collections</label>
             <div>
-              <CollectionList aria-labelledby="collections" :collections="Collections" />
+              <CollectionSelect aria-labelledby="collections" multiple v-model="Collections" />
             </div>
           </div>
         </div>
@@ -115,7 +115,7 @@ import CellPreparationInformation from "@/components/CellPreparationInformation"
 import TableOfContents from "@/components/TableOfContents";
 import ItemRelationshipVisualization from "@/components/ItemRelationshipVisualization";
 import FormattedRefcode from "@/components/FormattedRefcode";
-import CollectionList from "@/components/CollectionList";
+import CollectionSelect from "@/components/CollectionSelect";
 import Creators from "@/components/Creators";
 import { cellFormats } from "@/resources.js";
 
@@ -154,7 +154,7 @@ export default {
     TableOfContents,
     ItemRelationshipVisualization,
     FormattedRefcode,
-    CollectionList,
+    CollectionSelect,
     Creators,
   },
 };

--- a/webapp/src/components/CollectionSelect.vue
+++ b/webapp/src/components/CollectionSelect.vue
@@ -9,7 +9,7 @@
   >
     <template #no-options="{ searching }">
       <span v-if="searching"> Sorry, no matches found. </span>
-      <span v-else class="empty-search"> Type a search term... </span>
+      <span v-else class="empty-search"> Search for a collection... </span>
     </template>
     <template v-slot:option="{ collection_id, title }">
       <FormattedCollectionName
@@ -19,10 +19,9 @@
         :maxLength="formattedItemNameMaxLength"
       />
     </template>
-    <template v-slot:selected-option="{ collection_id, title }">
+    <template v-slot:selected-option="{ collection_id }">
       <FormattedCollectionName
         :collection_id="collection_id"
-        :title="title"
         enableModifiedClick
         :maxLength="formattedItemNameMaxLength"
       />

--- a/webapp/src/components/CollectionSelect.vue
+++ b/webapp/src/components/CollectionSelect.vue
@@ -2,8 +2,8 @@
   <vSelect
     v-model="value"
     :options="collections"
+    multiple
     @search="debouncedAsyncSearch"
-    label="name"
     :filterable="false"
     ref="selectComponent"
   >
@@ -73,6 +73,12 @@ export default {
       this.debounceTimeout = setTimeout(async () => {
         await searchCollections(query, 100)
           .then((collections) => {
+            // check if the searched collections are already listed in the value
+            // if so, remove it from the list of options
+            if (this.value) {
+              const valueIds = this.value.map((item) => item.collection_id);
+              collections = collections.filter((item) => !valueIds.includes(item.collection_id));
+            }
             this.collections = collections;
           })
           .catch((error) => {

--- a/webapp/src/components/CollectionTable.vue
+++ b/webapp/src/components/CollectionTable.vue
@@ -4,10 +4,9 @@
   </div>
   <table class="table table-hover table-sm" data-testid="collection-table">
     <thead>
-      <tr align="center">
+      <tr>
         <th scope="col">ID</th>
         <th scope="col">Title</th>
-        <th scope="col"># of items</th>
         <th scope="col">Creators</th>
         <th scope="col"></th>
       </tr>
@@ -29,7 +28,6 @@
           />
         </td>
         <td align="left">{{ collection.title }}</td>
-        <td align="right">{{ collection.num_items || 0 }}</td>
         <td align="center"><Creators :creators="collection.creators" /></td>
         <td align="right">
           <button

--- a/webapp/src/components/FancyCollectionSampleTable.vue
+++ b/webapp/src/components/FancyCollectionSampleTable.vue
@@ -5,13 +5,25 @@
 
   <div class="form-inline mb-2 ml-auto mt-2">
     <div class="form-group">
-      <label for="sample-table-search" class="sr-only">Search items</label>
+      <label for="collection-table-search" class="sr-only">Filter items</label>
       <input
-        id="sample-table-search"
+        id="collection-table-search"
         type="text"
         class="form-control"
         v-model="searchValue"
         placeholder="Search within collection"
+      />
+    </div>
+    <div class="col-md-6">
+      <label id="add-to-collection" class="sr-only">Add items</label>
+      <ItemSelect
+        id="add-to-collection-select"
+        class="select-in-row"
+        :modelValue="selectedItemToAdd"
+        @update:modelValue="
+          selectedItemToAdd = $event;
+          addItemFromSearch();
+        "
       />
     </div>
   </div>
@@ -28,7 +40,6 @@
     header-class-name="customize-table-header"
     buttons-pagination
     @click-row="goToEditPage"
-    v-model:items-selected="itemsSelected"
   >
     <template #empty-message>Collection is empty.</template>
 
@@ -60,7 +71,8 @@ import "vue3-easy-data-table/dist/style.css";
 import FormattedItemName from "@/components/FormattedItemName";
 import ChemicalFormula from "@/components/ChemicalFormula";
 import Creators from "@/components/Creators";
-import { getCollectionSampleList } from "@/server_fetch_utils.js";
+import { getCollectionSampleList, addItemToCollection } from "@/server_fetch_utils.js";
+import ItemSelect from "@/components/ItemSelect";
 // eslint-disable-next-line no-unused-vars
 import { itemTypes } from "@/resources.js";
 
@@ -73,6 +85,7 @@ export default {
       isSampleFetchError: false,
       itemTypes: itemTypes,
       sampleTableIsReady: false,
+      selectedItemToAdd: null,
       itemsSelected: [],
       headers: [
         { text: "ID", value: "item_id", sortable: true },
@@ -92,6 +105,11 @@ export default {
     },
   },
   methods: {
+    addItemFromSearch() {
+      if (this.selectedItemToAdd) {
+        addItemToCollection(this.selectedItemToAdd, this.collection_id);
+      }
+    },
     getCollectionSamples() {
       getCollectionSampleList(this.collection_id)
         .then(() => {
@@ -115,21 +133,6 @@ export default {
         this.$router.push(`/edit/${row.item_id}`);
       }
     },
-    deleteSelectedItems() {
-      const idsSelected = this.itemsSelected.map((x) => x.item_id);
-      if (
-        confirm(
-          `Are you sure you want to remove ${this.itemsSelected.length} selected items (${idsSelected}) from this collection?`,
-        )
-      ) {
-        console.log("deleting...");
-        idsSelected.forEach((item_id) => {
-          console.log(`deleting item ${item_id}`);
-        });
-      } else {
-        console.log("delete cancelled...");
-      }
-    },
   },
   created() {
     this.getCollectionSamples();
@@ -139,6 +142,7 @@ export default {
     ChemicalFormula,
     Creators,
     FormattedItemName,
+    ItemSelect,
   },
 };
 </script>

--- a/webapp/src/components/FancyCollectionSampleTable.vue
+++ b/webapp/src/components/FancyCollectionSampleTable.vue
@@ -4,13 +4,6 @@
   </div>
 
   <div class="form-inline mb-2 ml-auto mt-2">
-    <button
-      class="btn btn-default ml-auto mr-2"
-      :disabled="!Boolean(itemsSelected.length)"
-      @click="deleteSelectedItems"
-    >
-      Remove selected...
-    </button>
     <div class="form-group">
       <label for="sample-table-search" class="sr-only">Search items</label>
       <input
@@ -18,7 +11,7 @@
         type="text"
         class="form-control"
         v-model="searchValue"
-        placeholder="search"
+        placeholder="Search within collection"
       />
     </div>
   </div>

--- a/webapp/src/components/SampleInformation.vue
+++ b/webapp/src/components/SampleInformation.vue
@@ -33,10 +33,10 @@
               <Creators aria-labelledby="creators" :creators="ItemCreators" :size="36" />
             </div>
           </div>
-          <div class="form-group col-md-3">
+          <div class="form-group col-md">
             <label id="collections" class="mr-2">Collections</label>
             <div>
-              <CollectionList aria-labelledby="collections" :collections="Collections" />
+              <CollectionSelect aria-labelledby="collections" multiple v-model="Collections" />
             </div>
           </div>
         </div>
@@ -65,7 +65,7 @@
 import { createComputedSetterForItemField } from "@/field_utils.js";
 import ChemFormulaInput from "@/components/ChemFormulaInput";
 import FormattedRefcode from "@/components/FormattedRefcode";
-import CollectionList from "@/components/CollectionList";
+import CollectionSelect from "@/components/CollectionSelect";
 import TinyMceInline from "@/components/TinyMceInline";
 import SynthesisInformation from "@/components/SynthesisInformation";
 import TableOfContents from "@/components/TableOfContents";
@@ -103,7 +103,7 @@ export default {
     TableOfContents,
     ItemRelationshipVisualization,
     FormattedRefcode,
-    CollectionList,
+    CollectionSelect,
     Creators,
   },
 };

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -154,6 +154,18 @@ export function createNewCollection(collection_id, title, startingData = {}, cop
   });
 }
 
+export function addItemToCollection(item, collection_id) {
+  return fetch_post(`${API_URL}/save-item/`, {
+    item_id: item.item_id,
+    data: {
+      collections: [{ collection_id: collection_id }],
+    },
+  }).then(function () {
+    store.commit("addItemToCollection", item, collection_id);
+    return "success";
+  });
+}
+
 export async function getStats() {
   return fetch_get(`${API_URL}/info/stats`)
     .then(function (response_json) {
@@ -410,6 +422,8 @@ export function saveCollection(collection_id) {
       alert("Save unsuccessful :(", error);
     });
 }
+
+// export function addToCollection(collection_id) {
 
 export function deleteBlock(item_id, block_id) {
   console.log("deleteBlock called!");

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -51,6 +51,10 @@ export default createStore({
       // collectionSummary is a json object summarizing the new collection
       state.collection_list.unshift(collectionSummary);
     },
+    addItemToCollection(state, payload) {
+      // Adds an item in "summarized" form to a collection
+      state.all_collection_children[payload.collection_id].push(payload.item);
+    },
     deleteFromSampleList(state, item_id) {
       const index = state.sample_list.map((e) => e.item_id).indexOf(item_id);
       if (index > -1) {


### PR DESCRIPTION
Builds on #553, still some outstanding work to do.

One way of hacking in a "add item to collection" route would be to treat the following cases in `/save-item`:

- If `/save-item` is called with `collections: [{"collection_id": "coll1"}]` then after saving the item should only be in coll1 even if it was already in coll2
-  If `/save-item` is called with `collections: {"collection_id": "coll1"}` then after saving the item should be added to coll1 but not removed from any other colls
- If `/save-item` is called with `collections: []` then remove the item from all collections.

We will run into this pattern a lot when writing the Python API, i.e., whether you should be able to modify only the provided parts of a sample, or whether you always have to provide the full state to avoid deleting other fields (e.g., whether it should behave like a dictionary assignment or `.update()` in Python)