### PR TITLE
Add process lock for remote filesystem scraper

### DIFF
--- a/pydatalab/pydatalab/config.py
+++ b/pydatalab/pydatalab/config.py
@@ -101,9 +101,12 @@ class RemoteFilesystem(BaseModel):
     accessible from the server.
     """
 
-    name: str
-    hostname: Optional[str]
-    path: Path
+    name: str = Field(description="The name of the filesystem to use in the UI.")
+    hostname: Optional[str] = Field(
+        None,
+        description="The hostname for the filesystem. `None` indicates the filesystem is already mounted locally.",
+    )
+    path: Path = Field(description="The path to the base of the filesystem to include.")
 
 
 class SMTPSettings(BaseModel):

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -183,6 +183,11 @@ def generate_api_key():
     return "".join(random.choices("abcdef0123456789", k=24))
 
 
+@pytest.fixture(scope="function")
+def random_string():
+    return generate_api_key()
+
+
 @pytest.fixture(scope="session")
 def admin_api_key() -> str:
     return generate_api_key()


### PR DESCRIPTION
Closes #539.

This PR adds a (manual) database lock so that multiple processes do not try to scrape the same filesystems repeatedly, which is the case in production when there are multiple worker processes running the API.

Still need to add unit tests for this; i.e., manually updating the lock and making sure that stale locks (older than the min cache age) are correctly swept away.