### PR TITLE
Bump navani to support ECLab <=11.50

### DIFF
--- a/pydatalab/Pipfile
+++ b/pydatalab/Pipfile
@@ -28,7 +28,7 @@ flask-compress = "*"
 pillow = "*"
 openai = "~= 0.28"
 tiktoken = "*"
-navani = {git = "git+https://github.com/the-grey-group/navani.git@v0.1.4"}
+navani = {git = "git+https://github.com/the-grey-group/navani.git@v0.1.5-rc1"}
 python-dateutil = "*"
 pybaselines = "*"
 rosettasciio = "*"


### PR DESCRIPTION
Closes #538.

This PR still uses the pre-release of both navani and galvani, and will need to be updated when they are both released.