### PR TITLE
Add spacing above logo

### DIFF
--- a/webapp/src/components/Navbar.vue
+++ b/webapp/src/components/Navbar.vue
@@ -1,5 +1,5 @@
 <template>
-  <div v-if="this.logo_url != null">
+  <div class="pt-1" v-if="this.logo_url != null">
     <a v-if="this.homepage_url != null" :href="this.homepage_url" target="_blank">
       <img class="logo-banner" :src="this.logo_url" />
     </a>


### PR DESCRIPTION
Quick change to add space above the logo. There is currently no space, which looks odd if the logo .png doesn't have space in it:
![Screen Shot 2024-02-12 at 5 05 39 PM](https://github.com/the-grey-group/datalab/assets/32345545/db115691-425d-4c0d-821e-29c1723c4cb0)
