### PR TITLE
Downgrade pre-commit prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,7 +31,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: v3.0.3
     hooks:
       - id: prettier
         types_or: [javascript, jsx, vue, html, yaml]


### PR DESCRIPTION
Related to #589; downgrades pre-commit prettier to use the same version as package.json.