### PR TITLE
Fix issue where previously uploaded file cannot be replaced

### DIFF
--- a/pydatalab/pydatalab/file_utils.py
+++ b/pydatalab/pydatalab/file_utils.py
@@ -296,7 +296,7 @@ def update_uploaded_file(file, file_id, last_modified=None, size_bytes=None):
     updated_file_entry = File(**updated_file_entry)
 
     # overwrite the old file with the new location
-    file.save(updated_file_entry["location"])
+    file.save(updated_file_entry.location)
 
     ret = updated_file_entry.dict()
     ret.update({"_id": file_id})

--- a/pydatalab/tests/server/test_files.py
+++ b/pydatalab/tests/server/test_files.py
@@ -1,5 +1,6 @@
-import pytest
 import shutil
+
+import pytest
 
 from pydatalab.config import CONFIG
 
@@ -67,7 +68,9 @@ def test_get_file_and_delete(client, default_filepath, default_sample):
     assert not response.json["files_data"]
 
 
-def test_upload_new_version(client, default_filepath, insert_default_sample, default_sample, tmpdir):  # pylint: disable=unused-argument
+def test_upload_new_version(
+    client, default_filepath, insert_default_sample, default_sample, tmpdir
+):  # pylint: disable=unused-argument
     """Upload a file, then upload a new version of the same file."""
     with open(default_filepath, "rb") as f:
         response = client.post(
@@ -110,5 +113,8 @@ def test_upload_new_version(client, default_filepath, insert_default_sample, def
     assert response_reup.json["file_information"]
     assert response_reup.json["status"], "success"
     assert response_reup.status_code == 201
-    assert response_reup.json["file_information"]["location"] == response.json["file_information"]["location"]
+    assert (
+        response_reup.json["file_information"]["location"]
+        == response.json["file_information"]["location"]
+    )
     assert response_reup.json["file_id"] == response.json["file_id"]

--- a/pydatalab/tests/server/test_files.py
+++ b/pydatalab/tests/server/test_files.py
@@ -1,4 +1,5 @@
 import pytest
+import shutil
 
 from pydatalab.config import CONFIG
 
@@ -64,3 +65,50 @@ def test_get_file_and_delete(client, default_filepath, default_sample):
     assert response.status_code == 200
     assert not response.json["item_data"]["file_ObjectIds"]
     assert not response.json["files_data"]
+
+
+def test_upload_new_version(client, default_filepath, insert_default_sample, default_sample, tmpdir):  # pylint: disable=unused-argument
+    """Upload a file, then upload a new version of the same file."""
+    with open(default_filepath, "rb") as f:
+        response = client.post(
+            "/upload-file/",
+            buffered=True,
+            content_type="multipart/form-data",
+            data={
+                "item_id": default_sample.item_id,
+                "file": [(f, default_filepath.name)],
+                "type": "application/octet-stream",
+                "replace_file": "null",
+                "relativePath": "null",
+            },
+        )
+
+    file_id = response.json["file_id"]
+    assert file_id
+    assert response.json["file_information"]
+    assert response.json["status"], "success"
+    assert response.status_code == 201
+
+    # Copy the file to a new temp directory so its fs metadata changes
+    tmp_filepath = tmpdir / default_filepath.name
+    shutil.copy(default_filepath, tmp_filepath)
+
+    with open(tmp_filepath, "rb") as f:
+        response_reup = client.post(
+            "/upload-file/",
+            buffered=True,
+            content_type="multipart/form-data",
+            data={
+                "item_id": default_sample.item_id,
+                "file": [(f, default_filepath.name)],
+                "type": "application/octet-stream",
+                "replace_file": file_id,
+                "relativePath": "null",
+            },
+        )
+    assert isinstance(response_reup.json["file_id"], str)
+    assert response_reup.json["file_information"]
+    assert response_reup.json["status"], "success"
+    assert response_reup.status_code == 201
+    assert response_reup.json["file_information"]["location"] == response.json["file_information"]["location"]
+    assert response_reup.json["file_id"] == response.json["file_id"]


### PR DESCRIPTION
Right now, if you upload a file with the same name, it fails simply due to Python attribute access error. We should try to add a test in this PR that verifies this.

Closes #600 