### PR TITLE
Restrict relationship types in UI synthesis and constituents tables

### DIFF
--- a/webapp/src/components/CellPreparationInformation.vue
+++ b/webapp/src/components/CellPreparationInformation.vue
@@ -8,7 +8,11 @@
       >
       <div class="card component-card">
         <div class="card-body pt-2 pb-0 mb-0 pl-5">
-          <CompactConstituentTable id="pos-electrode-table" v-model="PosElectrodeConstituents" :typesToQuery='["starting_materials", "samples"]'/>
+          <CompactConstituentTable
+            id="pos-electrode-table"
+            v-model="PosElectrodeConstituents"
+            :typesToQuery="['starting_materials', 'samples']"
+          />
         </div>
       </div>
     </div>
@@ -19,7 +23,11 @@
       >
       <div class="card component-card">
         <div class="card-body pt-2 pb-0 mb-0 pl-5">
-            <CompactConstituentTable id="electrolyte-table" v-model="ElectrolyteConstituents" :typesToQuery='["starting_materials", "samples"]'/>
+          <CompactConstituentTable
+            id="electrolyte-table"
+            v-model="ElectrolyteConstituents"
+            :typesToQuery="['starting_materials', 'samples']"
+          />
         </div>
       </div>
     </div>
@@ -30,7 +38,11 @@
       >
       <div class="card component-card">
         <div class="card-body pt-2 pb-0 mb-0 pl-5">
-          <CompactConstituentTable id="neg-electrode-table" v-model="NegElectrodeConstituents" :typesToQuery='["starting_materials", "samples"]' />
+          <CompactConstituentTable
+            id="neg-electrode-table"
+            v-model="NegElectrodeConstituents"
+            :typesToQuery="['starting_materials', 'samples']"
+          />
         </div>
       </div>
     </div>

--- a/webapp/src/components/CellPreparationInformation.vue
+++ b/webapp/src/components/CellPreparationInformation.vue
@@ -8,7 +8,7 @@
       >
       <div class="card component-card">
         <div class="card-body pt-2 pb-0 mb-0 pl-5">
-          <CompactConstituentTable id="pos-electrode-table" v-model="PosElectrodeConstituents" />
+          <CompactConstituentTable id="pos-electrode-table" v-model="PosElectrodeConstituents" :typesToQuery='["starting_materials", "samples"]'/>
         </div>
       </div>
     </div>
@@ -19,7 +19,7 @@
       >
       <div class="card component-card">
         <div class="card-body pt-2 pb-0 mb-0 pl-5">
-          <CompactConstituentTable id="electrolyte-table" v-model="ElectrolyteConstituents" />
+            <CompactConstituentTable id="electrolyte-table" v-model="ElectrolyteConstituents" :typesToQuery='["starting_materials", "samples"]'/>
         </div>
       </div>
     </div>
@@ -30,7 +30,7 @@
       >
       <div class="card component-card">
         <div class="card-body pt-2 pb-0 mb-0 pl-5">
-          <CompactConstituentTable id="neg-electrode-table" v-model="NegElectrodeConstituents" />
+          <CompactConstituentTable id="neg-electrode-table" v-model="NegElectrodeConstituents" :typesToQuery='["starting_materials", "samples"]' />
         </div>
       </div>
     </div>

--- a/webapp/src/components/CompactConstituentTable.vue
+++ b/webapp/src/components/CompactConstituentTable.vue
@@ -23,6 +23,7 @@
             :ref="`select${index}`"
             v-model="selectedChangedConstituent"
             :clearable="false"
+            :typesToQuery="typesToQuery"
             @option:selected="swapConstituent($event, index)"
             @search:blur="selectShown[index] = false"
           />
@@ -88,6 +89,7 @@
             <ItemSelect
               taggable
               ref="newSelect"
+              :typesToQuery="typesToQuery"
               v-model="selectedNewConstituent"
               @option:selected="addConstituent"
             />
@@ -106,6 +108,10 @@ import { OnClickOutside } from "@vueuse/components";
 export default {
   props: {
     modelValue: Object,
+    typesToQuery: {
+      type: Array,
+      default: () => ["samples", "starting_materials", "cells"],
+    },
   },
   data() {
     return {

--- a/webapp/src/components/SynthesisInformation.vue
+++ b/webapp/src/components/SynthesisInformation.vue
@@ -3,7 +3,7 @@
     <label class="mr-2 pb-2">Synthesis Information</label>
     <div class="card component-card">
       <div class="card-body pt-2 pb-0 mb-0 pl-5">
-        <CompactConstituentTable id="synthesis-table" v-model="constituents" />
+        <CompactConstituentTable id="synthesis-table" v-model="constituents" :typesToQuery='["samples", "starting_materials"]'/>
       </div>
     </div>
     <span id="synthesis-procedure-label" class="subheading ml-2">Procedure</span>

--- a/webapp/src/components/SynthesisInformation.vue
+++ b/webapp/src/components/SynthesisInformation.vue
@@ -3,7 +3,11 @@
     <label class="mr-2 pb-2">Synthesis Information</label>
     <div class="card component-card">
       <div class="card-body pt-2 pb-0 mb-0 pl-5">
-        <CompactConstituentTable id="synthesis-table" v-model="constituents" :typesToQuery='["samples", "starting_materials"]'/>
+        <CompactConstituentTable
+          id="synthesis-table"
+          v-model="constituents"
+          :typesToQuery="['samples', 'starting_materials']"
+        />
       </div>
     </div>
     <span id="synthesis-procedure-label" class="subheading ml-2">Procedure</span>

--- a/webapp/src/components/itemCreateModalAddons/CellCreateModalAddon.vue
+++ b/webapp/src/components/itemCreateModalAddons/CellCreateModalAddon.vue
@@ -9,7 +9,7 @@
         aria-labelledby="posConstituentsLabel"
         multiple
         v-model="posElectrodeConstituents"
-        :typesToQuery='["samples", "starting_materials"]'
+        :typesToQuery="['samples', 'starting_materials']"
         taggable
         class="col-sm-9"
       />
@@ -23,7 +23,7 @@
         aria-labelledby="elyteConstituentsLabel"
         multiple
         v-model="electrolyteConstituents"
-        :typesToQuery='["samples", "starting_materials"]'
+        :typesToQuery="['samples', 'starting_materials']"
         taggable
         class="col-sm-9"
       />
@@ -37,7 +37,7 @@
         aria-labelledby="negConstituentsLabel"
         multiple
         v-model="negElectrodeConstituents"
-        :typesToQuery='["samples", "starting_materials"]'
+        :typesToQuery="['samples', 'starting_materials']"
         taggable
         class="col-sm-9"
       />

--- a/webapp/src/components/itemCreateModalAddons/CellCreateModalAddon.vue
+++ b/webapp/src/components/itemCreateModalAddons/CellCreateModalAddon.vue
@@ -9,6 +9,7 @@
         aria-labelledby="posConstituentsLabel"
         multiple
         v-model="posElectrodeConstituents"
+        :typesToQuery='["samples", "starting_materials"]'
         taggable
         class="col-sm-9"
       />
@@ -22,6 +23,7 @@
         aria-labelledby="elyteConstituentsLabel"
         multiple
         v-model="electrolyteConstituents"
+        :typesToQuery='["samples", "starting_materials"]'
         taggable
         class="col-sm-9"
       />
@@ -35,6 +37,7 @@
         aria-labelledby="negConstituentsLabel"
         multiple
         v-model="negElectrodeConstituents"
+        :typesToQuery='["samples", "starting_materials"]'
         taggable
         class="col-sm-9"
       />

--- a/webapp/src/components/itemCreateModalAddons/SampleCreateModalAddon.vue
+++ b/webapp/src/components/itemCreateModalAddons/SampleCreateModalAddon.vue
@@ -5,6 +5,7 @@
       <ItemSelect
         aria-labelledby="startWithConstituentsLabel"
         multiple
+        :typesToQuery="['samples', 'starting_materials']"
         taggable
         v-model="constituents"
       />


### PR DESCRIPTION
Closes #628 by restricting the types that are searched for in the synthesis/constituents tables.