### PR TITLE
Allow browser context menu in tinymce fields

### DIFF
--- a/webapp/src/components/TinyMceInline.vue
+++ b/webapp/src/components/TinyMceInline.vue
@@ -13,6 +13,7 @@
         width: '50%',
         'margin-left': '1rem',
       },
+      contextmenu: false,
       toolbar:
         'bold italic underline strikethrough superscript subscript forecolor backcolor removeformat | 		alignleft aligncenter alignright | bullist numlist indent outdent | headergroup insertgroup | table',
       toolbar_groups: {


### PR DESCRIPTION
Currently, it is not possible to copy or paste from the right click context window in our tinymce fields. Tinymce has a copy/paste functionality, but apparently it is blocked in many browsers. So, the best option for now seems to be to not use tinymce's contextmenu at all, and instead enable the default browser right click.

closes #633


