### PR TITLE
Add optional functionality to add starting materials from within the webapp

### DIFF
--- a/pydatalab/pydatalab/models/starting_materials.py
+++ b/pydatalab/pydatalab/models/starting_materials.py
@@ -31,6 +31,12 @@ class StartingMaterial(Item):
 
     full_percent: Optional[str] = Field(alias="Full %")
 
+    GHS_codes: Optional[str] = Field(
+        alias="GHS H-codes",
+        description="A string describing any GHS hazard codes associated with this item. See https://pubchem.ncbi.nlm.nih.gov/ghs/ for code definitions.",
+        examples=["H224", "H303, H316, H319"],
+    )
+
     name: Optional[str] = Field(alias="Container Name", description="name of the chemical")
 
     size: Optional[str] = Field(

--- a/pydatalab/pydatalab/models/starting_materials.py
+++ b/pydatalab/pydatalab/models/starting_materials.py
@@ -17,7 +17,7 @@ class StartingMaterial(Item):
         alias="Barcode", description="A unique barcode from ChemInventory"
     )
 
-    date_acquired: Optional[IsoformatDateTime] = Field(
+    date: Optional[IsoformatDateTime] = Field(
         alias="Date Acquired", description="The date the item was acquired"
     )
 

--- a/pydatalab/pydatalab/models/starting_materials.py
+++ b/pydatalab/pydatalab/models/starting_materials.py
@@ -31,7 +31,7 @@ class StartingMaterial(Item):
 
     full_percent: Optional[str] = Field(alias="Full %")
 
-    name: str = Field(alias="Container Name", description="name of the chemical")
+    name: Optional[str] = Field(alias="Container Name", description="name of the chemical")
 
     size: Optional[str] = Field(
         alias="Container Size", description="size of the container (see 'size_unit' for the units)"

--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -393,11 +393,20 @@ def _create_sample(sample_dict: dict, copy_from_item_id: Optional[str] = None) -
     if type not in ITEM_MODELS:
         raise RuntimeError("Invalid type")
     model = ITEM_MODELS[type]
-    schema = model.schema()
 
-    new_sample = {k: sample_dict[k] for k in schema["properties"] if k in sample_dict}
+    ## the following code was used previously to explicitely check schema properties.
+    ## it doesn't seem to be necessary now, with extra = "ignore" turned on in the pydantic models,
+    ## and it breaks in instances where the models use aliases (e.g., in the starting_material model)
+    ## so we are taking it out now, but leaving this comment in case it needs to be reverted.
+    # schema = model.schema()
+    # new_sample = {k: sample_dict[k] for k in schema["properties"] if k in sample_dict}
+    new_sample = sample_dict
 
-    if CONFIG.TESTING:
+    if type == "starting_materials":
+        # starting_materials are open to all in the deploment at this point, so no creators are assigned
+        new_sample["creator_ids"] = []
+        new_sample["creators"] = []
+    elif CONFIG.TESTING:
         # Set fake ID to ObjectId("000000000000000000000000") so a dummy user can be created
         # locally for testing creator UI elements
         new_sample["creator_ids"] = [24 * "0"]

--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -99,7 +99,7 @@ def get_starting_materials():
                         "_id": 0,
                         "item_id": 1,
                         "nblocks": {"$size": "$display_order"},
-                        "date_acquired": 1,
+                        "date": 1,
                         "chemform": 1,
                         "name": 1,
                         "chemical_purity": 1,

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -185,8 +185,7 @@
     }
   },
   "required": [
-    "item_id",
-    "name"
+    "item_id"
   ],
   "definitions": {
     "RelationshipType": {

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -144,6 +144,15 @@
       "title": "Full %",
       "type": "string"
     },
+    "GHS_codes": {
+      "title": "Ghs H-Codes",
+      "description": "A string describing any GHS hazard codes associated with this item. See https://pubchem.ncbi.nlm.nih.gov/ghs/ for code definitions.",
+      "examples": [
+        "H224",
+        "H303, H316, H319"
+      ],
+      "type": "string"
+    },
     "size": {
       "title": "Container Size",
       "description": "size of the container (see 'size_unit' for the units)",

--- a/pydatalab/schemas/startingmaterial.json
+++ b/pydatalab/schemas/startingmaterial.json
@@ -90,7 +90,8 @@
       "type": "string"
     },
     "date": {
-      "title": "Date",
+      "title": "Date Acquired",
+      "description": "The date the item was acquired",
       "type": "date",
       "format": "date-time"
     },
@@ -118,12 +119,6 @@
       "title": "Barcode",
       "description": "A unique barcode from ChemInventory",
       "type": "string"
-    },
-    "date_acquired": {
-      "title": "Date Acquired",
-      "description": "The date the item was acquired",
-      "type": "date",
-      "format": "date-time"
     },
     "date_opened": {
       "title": "Date Opened",

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -193,6 +193,11 @@ def fixture_default_starting_material():
             "chemform": "Na2CO3",
             "name": "Sodium carbonate",
             "date": "1992-12-11",
+            "date_opened": "2022-12-11",
+            "CAS": "497-19-8",
+            "chemical_purity": "99%",
+            "location": "SR1 room 22",
+            "GHS_codes": "H303, H316, H319",
             "type": "starting_materials",
         }
     )

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -185,6 +185,19 @@ def fixture_default_collection():
     )
 
 
+@pytest.fixture(scope="module", name="default_starting_material")
+def fixture_default_starting_material():
+    return StartingMaterial(
+        **{
+            "item_id": "test_sm",
+            "chemform": "Na2CO3",
+            "name": "Sodium carbonate",
+            "date": "1992-12-11",
+            "type": "starting_materials",
+        }
+    )
+
+
 @pytest.fixture(scope="module", name="complicated_sample")
 def fixture_complicated_sample():
     from pydatalab.models.samples import Constituent
@@ -275,7 +288,7 @@ def example_items():
                     "item_id": "material",
                     "chemform": "NaNiO2",
                     "name": "new material",
-                    "date_acquired": "1970-02-01",
+                    "date": "1970-02-01",
                     "refcode": "grey:TEST4",
                 }
             ),
@@ -284,7 +297,7 @@ def example_items():
                     "item_id": "test",
                     "chemform": "NaNiO2",
                     "name": "NaNiO2",
-                    "date_acquired": "1970-02-01",
+                    "date": "1970-02-01",
                     "refcode": "grey:TEST5",
                 }
             ),
@@ -300,3 +313,8 @@ def fixture_default_sample_dict(default_sample):
 @pytest.fixture(scope="module", name="default_cell_dict")
 def fixture_default_cell_dict(default_cell):
     return default_cell.dict(exclude_unset=True)
+
+
+@pytest.fixture(scope="module", name="default_starting_material_dict")
+def fixture_default_starting_material_dict(default_starting_material):
+    return default_starting_material.dict(exclude_unset=True)

--- a/pydatalab/tests/server/test_startingmaterials.py
+++ b/pydatalab/tests/server/test_startingmaterials.py
@@ -1,0 +1,95 @@
+import datetime
+
+import pytest
+
+
+@pytest.mark.dependency()
+def test_empty_starting_materials(client):
+    response = client.get("/starting-materials/")
+    assert len(response.json["items"]) == 0
+    assert response.status_code == 200
+
+
+@pytest.mark.dependency(depends=["test_empty_starting_materials"])
+def test_new_starting_material(client, default_starting_material_dict):
+    print(default_starting_material_dict)
+    response = client.post("/new-sample/", json=default_starting_material_dict)
+    # Test that 201: Created is emitted
+    assert response.status_code == 201, response.json
+    assert response.json["status"] == "success"
+    print(response.json["sample_list_entry"])
+
+    # all starting materials should have no creators currently (they are shared among a deployment):
+    assert len(response.json["sample_list_entry"]["creators"]) == 0
+
+    for key, value in response.json["sample_list_entry"].items():
+        if key in default_starting_material_dict:
+            if isinstance(v := default_starting_material_dict[key], datetime.datetime):
+                v = v.isoformat()
+            assert value == v
+
+
+@pytest.mark.dependency(depends=["test_new_starting_material"])
+def test_get_item_data(client, default_starting_material_dict):
+    response = client.get("/get-item-data/test_sm")
+    assert response.status_code == 200
+    assert response.json["status"] == "success"
+
+    # all starting materials should have no creators currently (they are shared among a deployment):
+    assert len(response.json["item_data"]["creators"]) == 0
+    assert len(response.json["item_data"]["creator_ids"]) == 0
+
+    for key in default_starting_material_dict.keys():
+        if isinstance(v := default_starting_material_dict[key], datetime.datetime):
+            v = v.isoformat()
+        assert response.json["item_data"][key] == v
+
+
+@pytest.mark.dependency(depends=["test_new_starting_material"])
+def test_new_starting_material_collision(client, default_starting_material_dict):
+    # Try to do the same thing again, expecting an ID collision
+    response = client.post("/new-sample/", json=default_starting_material_dict)
+    # Test that 409: Conflict is returned
+    assert response.status_code == 409
+    assert (
+        response.json["message"]
+        == "item_id_validation_error: 'test_sm' already exists in database."
+    )
+
+
+@pytest.mark.dependency(depends=["test_new_starting_material"])
+def test_save_good_sample(client, default_starting_material_dict):
+    updated_starting_material = default_starting_material_dict.copy()
+    updated_starting_material.update({"description": "This is a newer test sample."})
+    response = client.post(
+        "/save-item/",
+        json={
+            "item_id": default_starting_material_dict["item_id"],
+            "data": updated_starting_material,
+        },
+    )
+    assert response.status_code == 200, response.json
+    assert response.json["status"] == "success"
+
+    response = client.get("/get-item-data/test_sm")
+    assert response.status_code == 200
+    assert response.json["status"] == "success"
+    for key in default_starting_material_dict.keys():
+        if key in updated_starting_material and key in response.json:
+            assert response.json[key] == updated_starting_material[key]
+
+
+@pytest.mark.dependency(depends=["test_new_starting_material"])
+def test_delete_sample(client, default_starting_material_dict):
+    response = client.post(
+        "/delete-sample/",
+        json={"item_id": default_starting_material_dict["item_id"]},
+    )
+    assert response.status_code == 200
+    assert response.json["status"] == "success"
+
+    # Check it was actually deleted
+    response = client.get(
+        f"/get-item-data/{default_starting_material_dict['item_id']}",
+    )
+    assert response.status_code == 404

--- a/webapp/cypress/e2e/editPage.cy.js
+++ b/webapp/cypress/e2e/editPage.cy.js
@@ -36,7 +36,7 @@ describe("Edit Page", () => {
 
   it("Adds a valid sample", () => {
     cy.findByText("Add an item").click();
-    cy.findByText("Add new sample").should("exist");
+    cy.findByText("Add new item").should("exist");
     cy.findByLabelText("ID:").type("editable_sample");
     cy.findByLabelText("Date Created:").type("1990-01-07T00:00");
 
@@ -50,7 +50,7 @@ describe("Edit Page", () => {
 
   it("Adds a second valid sample, to use as a component", () => {
     cy.findByText("Add an item").click();
-    cy.findByText("Add new sample");
+    cy.findByText("Add new item");
     cy.findByLabelText("ID:").type("component1");
     cy.get("#sample-name").type("This is a component");
     cy.get("#sample-submit").click();
@@ -58,7 +58,7 @@ describe("Edit Page", () => {
 
   it("Adds a third valid sample, to use as a component", () => {
     cy.findByText("Add an item").click();
-    cy.findByText("Add new sample");
+    cy.findByText("Add new item");
     cy.findByLabelText("ID:").type("component2");
     cy.get("#sample-name").type("This is another component");
     cy.get("#sample-submit").click();

--- a/webapp/cypress/e2e/sampleTablePage.cy.js
+++ b/webapp/cypress/e2e/sampleTablePage.cy.js
@@ -42,7 +42,7 @@ describe("Sample table page", () => {
 
   it("Adds a valid sample", () => {
     cy.findByText("Add an item").click();
-    cy.findByText("Add new sample").should("exist");
+    cy.findByText("Add new item").should("exist");
     cy.findByLabelText("ID:").type("12345678910");
     cy.findByLabelText("Date Created:").type("1990-01-07T00:00");
 
@@ -77,7 +77,7 @@ describe("Sample table page", () => {
 
   it("Attempts to Add an item with the same name", () => {
     cy.findByText("Add an item").click();
-    cy.findByText("Add new sample").should("exist");
+    cy.findByText("Add new item").should("exist");
     cy.findByLabelText("ID:").type("12345678910");
 
     cy.contains("already in use").should("exist");

--- a/webapp/cypress/support/commands.js
+++ b/webapp/cypress/support/commands.js
@@ -31,10 +31,10 @@ import "@testing-library/cypress/add-commands";
 const TODAY = new Date().toISOString().slice(0, -8);
 const API_URL = Cypress.config("apiUrl");
 
-Cypress.Commands.add("createSample", (sample_id, name = null, date = null) => {
+Cypress.Commands.add("createSample", (item_id, name = null, date = null) => {
   cy.findByText("Add an item").click();
-  cy.findByText("Add new sample").should("exist");
-  cy.findByLabelText("ID:").type(sample_id);
+  cy.findByText("Add new item").should("exist");
+  cy.findByLabelText("ID:").type(item_id);
   if (name) {
     cy.get("#sample-name").type(name);
   }
@@ -44,10 +44,10 @@ Cypress.Commands.add("createSample", (sample_id, name = null, date = null) => {
   cy.get("#sample-submit").click();
 });
 
-Cypress.Commands.add("verifySample", (sample_id, name = null, date = null) => {
+Cypress.Commands.add("verifySample", (item_id, name = null, date = null) => {
   if (date) {
     cy.get("[data-testid=sample-table]")
-      .contains(sample_id)
+      .contains(item_id)
       .parents("tr")
       .within(() => {
         cy.contains(date.slice(0, 8));
@@ -57,7 +57,7 @@ Cypress.Commands.add("verifySample", (sample_id, name = null, date = null) => {
       });
   } else {
     cy.get("[data-testid=sample-table]")
-      .contains(sample_id)
+      .contains(item_id)
       .parents("tr")
       .within(() => {
         cy.contains(TODAY.split("T")[0]);
@@ -68,12 +68,12 @@ Cypress.Commands.add("verifySample", (sample_id, name = null, date = null) => {
   }
 });
 
-Cypress.Commands.add("deleteSample", (sample_id, delay = 100) => {
+Cypress.Commands.add("deleteSample", (item_id, delay = 100) => {
   cy.visit("/");
   cy.wait(delay).then(() => {
-    cy.log("search for and delete: " + sample_id);
+    cy.log("search for and delete: " + item_id);
     cy.get("[data-testid=sample-table]")
-      .contains(new RegExp("^" + sample_id + "$", "g"))
+      .contains(new RegExp("^" + item_id + "$", "g"))
       .parents("tr")
       .within(() => {
         cy.get("button.close").click();
@@ -81,12 +81,12 @@ Cypress.Commands.add("deleteSample", (sample_id, delay = 100) => {
   });
 });
 
-Cypress.Commands.add("deleteSampleViaAPI", (sample_id) => {
-  cy.log("search for and delete: " + sample_id);
+Cypress.Commands.add("deleteSampleViaAPI", (item_id) => {
+  cy.log("search for and delete: " + item_id);
   cy.request({
     method: "POST",
     url: API_URL + "/delete-sample/",
-    body: { item_id: sample_id },
+    body: { item_id: item_id },
     failOnStatusCode: false,
   });
 });
@@ -110,9 +110,9 @@ Cypress.Commands.add(
   },
 );
 
-Cypress.Commands.add("removeAllTestSamples", (sample_ids) => {
+Cypress.Commands.add("removeAllTestSamples", (item_ids) => {
   // as contains matches greedily, if any IDs have matching substrings they must be added in the appropriate order
-  sample_ids = [
+  item_ids = [
     "editable_sample",
     "component1",
     "component2",
@@ -170,7 +170,7 @@ Cypress.Commands.add("removeAllTestSamples", (sample_ids) => {
     "testB",
     "testC",
   ];
-  sample_ids.forEach((item_id) => {
+  item_ids.forEach((item_id) => {
     cy.deleteSampleViaAPI(item_id);
   });
   cy.visit("/");

--- a/webapp/src/components/CreateItemModal.vue
+++ b/webapp/src/components/CreateItemModal.vue
@@ -18,8 +18,8 @@
           <div class="form-group col-md-6">
             <label for="item-type-select" class="col-form-label">Type:</label>
             <select v-model="item_type" class="form-control" id="item-type-select" required>
-              <option v-for="(obj, type) in availableTypes" :key="type" :value="type">
-                {{ obj.display }}
+              <option v-for="type in allowedTypes" :key="type" :value="type">
+                {{ itemTypes[type].display }}
               </option>
             </select>
           </div>
@@ -85,14 +85,14 @@
 import Modal from "@/components/Modal.vue";
 import ItemSelect from "@/components/ItemSelect.vue";
 import { createNewItem } from "@/server_fetch_utils.js";
-import { itemTypes } from "@/resources.js";
+import { itemTypes, SAMPLE_TABLE_TYPES } from "@/resources.js";
 import CollectionSelect from "@/components/CollectionSelect.vue";
 export default {
   name: "CreateItemModal",
   data() {
     return {
       item_id: null,
-      item_type: "samples",
+      item_type: "",
       date: this.now(),
       name: "",
       startingDataCallback: null,
@@ -101,17 +101,20 @@ export default {
       selectedItemToCopy: null,
       startingConstituents: [],
       agesAgo: new Date("1970-01-01").toISOString().slice(0, -8), // a datetime for the unix epoch start
-      //this is all just to filter an object in javascript:
-      availableTypes: Object.keys(itemTypes)
-        .filter((type) => itemTypes[type].isCreateable)
-        .reduce((newObj, key) => Object.assign(newObj, { [key]: itemTypes[key] }), {}),
     };
   },
   props: {
     modelValue: Boolean,
+    allowedTypes: {
+      type: Array,
+      default: () => SAMPLE_TABLE_TYPES,
+    },
   },
   emits: ["update:modelValue"],
   computed: {
+    itemTypes() {
+      return itemTypes;
+    },
     itemTypeDisplayName() {
       return itemTypes[this.item_type].display;
     },
@@ -207,6 +210,9 @@ export default {
       }
       this.name = `COPY OF ${this.selectedItemToCopy.name}`;
     },
+  },
+  created() {
+    this.item_type = this.allowedTypes[0];
   },
   components: {
     Modal,

--- a/webapp/src/components/CreateItemModal.vue
+++ b/webapp/src/components/CreateItemModal.vue
@@ -3,17 +3,17 @@
     <Modal
       :modelValue="modelValue"
       @update:modelValue="$emit('update:modelValue', $event)"
-      :disableSubmit="Boolean(sampleIDValidationMessage) || !Boolean(item_id)"
+      :disableSubmit="Boolean(itemIDValidationMessage) || !Boolean(item_id)"
       submitID="sample-submit"
     >
-      <template v-slot:header> Add new sample </template>
+      <template v-slot:header> Add new item </template>
 
       <template v-slot:body>
         <div class="form-row">
           <div class="form-group col-md-6">
-            <label for="sample-id" class="col-form-label">ID:</label>
-            <input v-model="item_id" type="text" class="form-control" id="sample-id" required />
-            <div class="form-error" v-html="sampleIDValidationMessage"></div>
+            <label for="item-id" class="col-form-label">ID:</label>
+            <input v-model="item_id" type="text" class="form-control" id="item-id" required />
+            <div class="form-error" v-html="itemIDValidationMessage"></div>
           </div>
           <div class="form-group col-md-6">
             <label for="item-type-select" class="col-form-label">Type:</label>
@@ -88,7 +88,7 @@ import { createNewItem } from "@/server_fetch_utils.js";
 import { itemTypes } from "@/resources.js";
 import CollectionSelect from "@/components/CollectionSelect.vue";
 export default {
-  name: "CreateSampleModal",
+  name: "CreateItemModal",
   data() {
     return {
       item_id: null,
@@ -123,7 +123,7 @@ export default {
         ? this.$store.state.sample_list.map((x) => x.item_id)
         : [];
     },
-    sampleIDValidationMessage() {
+    itemIDValidationMessage() {
       if (this.item_id == null) {
         return "";
       } // Don't throw an error before the user starts typing
@@ -145,7 +145,7 @@ export default {
   },
   methods: {
     async submitForm() {
-      console.log("new sample form submit triggered");
+      console.log("new item form submit triggered");
 
       // get any extra data by calling the optional callback from the type-specific addon component
       const extraData = this.startingDataCallback && this.startingDataCallback();
@@ -185,7 +185,7 @@ export default {
             console.log("error parsing error message", e);
           } finally {
             if (!is_item_id_error) {
-              alert("Error with creating new sample: " + error);
+              alert("Error with creating new item: " + error);
             }
           }
         });

--- a/webapp/src/components/FancyStartingMaterialTable.vue
+++ b/webapp/src/components/FancyStartingMaterialTable.vue
@@ -36,8 +36,8 @@
       <ChemicalFormula :formula="item.chemform" />
     </template>
 
-    <template #item-date_acquired="item">
-      {{ $filters.IsoDatetimeToDate(item.date_acquired) }}
+    <template #item-date="item">
+      {{ $filters.IsoDatetimeToDate(item.date) }}
     </template>
   </Vue3EasyDataTable>
 </template>
@@ -59,7 +59,7 @@ export default {
         { text: "ID", value: "item_id", sortable: true },
         { text: "Name", value: "name", sortable: true },
         { text: "Formula", value: "chemform", sortable: true },
-        { text: "Date", value: "date_acquired", sortable: true },
+        { text: "Date Acquired", value: "date", sortable: true },
         { text: "# of blocks", value: "nblocks", sortable: true },
       ],
     };

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -1,73 +1,57 @@
 <template>
-  <div class="container">
+  <div class="container-lg px-5 px-lg-0">
     <!-- Sample information -->
     <div id="starting-material-information" class="form-row">
-      <div class="form-group col-md-2 col-sm-4">
-        <label for="item_id" class="mr-2">Refcode</label>
+      <div class="form-group col-md-2 col-sm-3 col-sm-4">
+        <label for="item_id">Refcode</label>
         <div><FormattedRefcode :refcode="Refcode" /></div>
       </div>
-      <div class="form-group col-md-2 col-sm-4">
-        <label for="item_id" class="mr-2">Barcode</label>
-        <input id="item_id" class="form-control-plaintext" readonly="true" :value="item_id" />
+      <div class="form-group col-md-2 col-sm-3 col-sm-4">
+        <label for="item_id">Item ID</label>
+        <StyledInput id="item_id" readonly :modelValue="ItemID" />
       </div>
-      <div class="form-group col-md-6 col-sm-8">
-        <label for="name" class="mr-2">Name</label>
-        <input id="name" :value="item.name" class="form-control-plaintext" readonly="true" />
-      </div>
-      <div class="form-group col-md-2 col-sm-4">
-        <label for="date-opened" class="mr-2">Date acquired</label>
-        <input
-          id="date-opened"
-          :value="$filters.IsoDatetimeToDate(item.date_acquired)"
-          class="form-control-plaintext"
-          readonly="true"
-        />
-      </div>
-      <div class="form-group col-md-2 col-sm-4">
-        <label for="date-opened" class="mr-2">Date opened</label>
-        <input
-          id="date-opened"
-          :value="$filters.IsoDatetimeToDate(item.date_opened)"
-          class="form-control-plaintext"
-          readonly="true"
-        />
+      <div class="form-group col-lg-7 col-md-8 col-sm-8">
+        <label for="name">Name</label>
+        <StyledInput id="name" v-model="Name" :readonly="!isEditable" />
       </div>
     </div>
     <div class="form-row">
-      <div class="form-group col-md-3">
-        <label id="collections" class="mr-2">Collections</label>
-        <div>
-          <CollectionList aria-labelledby="collections" :collections="Collections" />
-        </div>
+      <div class="form-group col-md-3 col-sm-4">
+        <label for="date-acquired" class="mr-2">Date acquired</label>
+        <StyledInput
+          id="date-acquired"
+          type="date"
+          v-model="DateAcquired"
+          :readonly="!isEditable"
+        />
+      </div>
+      <div class="form-group col-md-3 col-sm-4">
+        <label for="date-opened" class="mr-2">Date opened</label>
+        <StyledInput id="date-opened" type="date" v-model="DateOpened" :readonly="!isEditable" />
+      </div>
+      <div class="form-group col-md-6 col-sm-4">
+        <label for="location" class="mr-2">Location</label>
+        <StyledInput id="location" v-model="Location" :readonly="!isEditable" />
+      </div>
+    </div>
+    <div class="form-row">
+      <div class="col-md-3">
+        <ToggleableCollectionFormGroup v-model="Collections" />
       </div>
       <div class="form-group col-md-3">
         <label for="chemform" class="mr-2">Chemical formula</label>
-        <span class="form-control-plaintext" readonly="true">
-          <ChemicalFormula :formula="item.chemform" />
-        </span>
+        <ChemFormulaInput v-if="isEditable" id="chemform" v-model="ChemForm" />
+        <ChemicalFormula v-if="!isEditable" id="chemform" :formula="ChemForm" />
       </div>
       <div class="form-group col-md-3">
         <label for="supplier" class="mr-2">Supplier</label>
-        <input
-          id="supplier"
-          :value="item.supplier"
-          class="form-control-plaintext"
-          readonly="true"
-        />
+        <StyledInput id="supplier" v-model="Supplier" :readonly="!isEditable" />
       </div>
       <div class="form-group col-md-3">
         <label for="purity" class="mr-2">Chemical purity</label>
-        <input
-          id="purity"
-          :value="item.chemical_purity"
-          class="form-control-plaintext"
-          readonly="true"
-        />
+        <StyledInput id="purity" v-model="ChemicalPurity" :readonly="!isEditable" />
       </div>
     </div>
-
-    <label for="location" class="mr-2">Location</label>
-    <input id="location" :value="item.location" class="form-control-plaintext" readonly="true" />
 
     <label class="mr-2">Description</label>
     <TinyMceInline v-model="ItemDescription"></TinyMceInline>
@@ -84,9 +68,13 @@
 import { createComputedSetterForItemField } from "@/field_utils.js";
 import TinyMceInline from "@/components/TinyMceInline";
 import ChemicalFormula from "@/components/ChemicalFormula";
+import ChemFormulaInput from "@/components/ChemFormulaInput";
 import TableOfContents from "@/components/TableOfContents";
-import CollectionList from "@/components/CollectionList";
+import ToggleableCollectionFormGroup from "@/components/ToggleableCollectionFormGroup";
 import FormattedRefcode from "@/components/FormattedRefcode";
+import StyledInput from "@/components/StyledInput";
+
+import { IS_STARTING_MATERIAL_EDITABLE } from "@/resources.js";
 
 export default {
   data() {
@@ -104,14 +92,27 @@ export default {
     item() {
       return this.$store.state.all_item_data[this.item_id];
     },
+    ItemID: createComputedSetterForItemField("item_id"),
+    Name: createComputedSetterForItemField("name"),
+    DateAcquired: createComputedSetterForItemField("date_acquired"),
+    DateOpened: createComputedSetterForItemField("date_opened"),
+    ChemForm: createComputedSetterForItemField("chemform"),
+    Supplier: createComputedSetterForItemField("supplier"),
+    ChemicalPurity: createComputedSetterForItemField("chemical_purity"),
+    Location: createComputedSetterForItemField("location"),
     ItemDescription: createComputedSetterForItemField("description"),
     Collections: createComputedSetterForItemField("collections"),
     Refcode: createComputedSetterForItemField("refcode"),
   },
+  created() {
+    this.isEditable = IS_STARTING_MATERIAL_EDITABLE;
+  },
   components: {
+    StyledInput,
     ChemicalFormula,
+    ChemFormulaInput,
     TinyMceInline,
-    CollectionList,
+    ToggleableCollectionFormGroup,
     TableOfContents,
     FormattedRefcode,
   },

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -19,7 +19,9 @@
       <div class="form-group col-lg-3 col-sm-4">
         <label for="chemform">Chemical formula</label>
         <ChemFormulaInput v-if="isEditable" id="chemform" v-model="ChemForm" />
-        <ChemicalFormula v-if="!isEditable" id="chemform" :formula="ChemForm" />
+        <span v-if="!isEditable" class="form-control-plaintext" readonly>
+          <ChemicalFormula id="chemform" :formula="ChemForm" />
+        </span>
       </div>
       <div class="form-group col-lg-3 col-sm-4">
         <label for="supplier">Supplier</label>

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -2,22 +2,37 @@
   <div class="container-lg px-5 px-lg-0">
     <!-- Sample information -->
     <div id="starting-material-information" class="form-row">
-      <div class="form-group col-md-2 col-sm-3 col-sm-4">
+      <div class="form-group col-md-2 col-sm-3 col-6">
         <label for="item_id">Refcode</label>
         <div><FormattedRefcode :refcode="Refcode" /></div>
       </div>
-      <div class="form-group col-md-2 col-sm-3 col-sm-4">
+      <div class="form-group col-md-2 col-sm-3 col-6">
         <label for="item_id">Item ID</label>
         <StyledInput id="item_id" readonly :modelValue="ItemID" />
       </div>
-      <div class="form-group col-lg-7 col-md-8 col-sm-8">
+      <div class="form-group col-lg-7 col-md-8 col-sm-6">
         <label for="name">Name</label>
         <StyledInput id="name" v-model="Name" :readonly="!isEditable" />
       </div>
     </div>
     <div class="form-row">
-      <div class="form-group col-md-3 col-sm-4">
-        <label for="date-acquired" class="mr-2">Date acquired</label>
+      <div class="form-group col-lg-3 col-sm-4">
+        <label for="chemform">Chemical formula</label>
+        <ChemFormulaInput v-if="isEditable" id="chemform" v-model="ChemForm" />
+        <ChemicalFormula v-if="!isEditable" id="chemform" :formula="ChemForm" />
+      </div>
+      <div class="form-group col-lg-3 col-sm-4">
+        <label for="supplier">Supplier</label>
+        <StyledInput id="supplier" v-model="Supplier" :readonly="!isEditable" />
+      </div>
+      <div class="form-group col-lg-3 col-sm-4">
+        <label for="purity">Chemical purity</label>
+        <StyledInput id="purity" v-model="ChemicalPurity" :readonly="!isEditable" />
+      </div>
+    </div>
+    <div class="form-row">
+      <div class="form-group col-lg-3 col-sm-4">
+        <label for="date-acquired">Date acquired</label>
         <StyledInput
           id="date-acquired"
           type="date"
@@ -25,31 +40,27 @@
           :readonly="!isEditable"
         />
       </div>
-      <div class="form-group col-md-3 col-sm-4">
-        <label for="date-opened" class="mr-2">Date opened</label>
+      <div class="form-group col-lg-3 col-sm-4">
+        <label for="date-opened">Date opened</label>
         <StyledInput id="date-opened" type="date" v-model="DateOpened" :readonly="!isEditable" />
       </div>
-      <div class="form-group col-md-6 col-sm-4">
-        <label for="location" class="mr-2">Location</label>
+      <div class="form-group col-lg-3 col-sm-4">
+        <label for="location">Location</label>
         <StyledInput id="location" v-model="Location" :readonly="!isEditable" />
       </div>
     </div>
+
     <div class="form-row">
-      <div class="col-md-3">
+      <div class="form-group col-lg-3 col-sm-4">
+        <label for="cas">CAS</label>
+        <StyledInput id="cas" v-model="CAS" :readonly="!isEditable" />
+      </div>
+      <div class="form-group col-lg-3 col-sm-4">
+        <label for="hazards">GHS Hazard Codes</label>
+        <StyledInput id="hazards" v-model="GHS" :readonly="!isEditable" />
+      </div>
+      <div class="col-lg-3 col-sm-4">
         <ToggleableCollectionFormGroup v-model="Collections" />
-      </div>
-      <div class="form-group col-md-3">
-        <label for="chemform" class="mr-2">Chemical formula</label>
-        <ChemFormulaInput v-if="isEditable" id="chemform" v-model="ChemForm" />
-        <ChemicalFormula v-if="!isEditable" id="chemform" :formula="ChemForm" />
-      </div>
-      <div class="form-group col-md-3">
-        <label for="supplier" class="mr-2">Supplier</label>
-        <StyledInput id="supplier" v-model="Supplier" :readonly="!isEditable" />
-      </div>
-      <div class="form-group col-md-3">
-        <label for="purity" class="mr-2">Chemical purity</label>
-        <StyledInput id="purity" v-model="ChemicalPurity" :readonly="!isEditable" />
       </div>
     </div>
 
@@ -94,6 +105,8 @@ export default {
     },
     ItemID: createComputedSetterForItemField("item_id"),
     Name: createComputedSetterForItemField("name"),
+    CAS: createComputedSetterForItemField("CAS"),
+    GHS: createComputedSetterForItemField("GHS_codes"),
     DateAcquired: createComputedSetterForItemField("date_acquired"),
     DateOpened: createComputedSetterForItemField("date_opened"),
     ChemForm: createComputedSetterForItemField("chemform"),

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -85,7 +85,7 @@ import ToggleableCollectionFormGroup from "@/components/ToggleableCollectionForm
 import FormattedRefcode from "@/components/FormattedRefcode";
 import StyledInput from "@/components/StyledInput";
 
-import { IS_STARTING_MATERIAL_EDITABLE } from "@/resources.js";
+import { EDITABLE_INVENTORY } from "@/resources.js";
 
 export default {
   data() {
@@ -118,7 +118,7 @@ export default {
     Refcode: createComputedSetterForItemField("refcode"),
   },
   created() {
-    this.isEditable = IS_STARTING_MATERIAL_EDITABLE;
+    this.isEditable = EDITABLE_INVENTORY;
   },
   components: {
     StyledInput,

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -109,7 +109,7 @@ export default {
     Name: createComputedSetterForItemField("name"),
     CAS: createComputedSetterForItemField("CAS"),
     GHS: createComputedSetterForItemField("GHS_codes"),
-    DateAcquired: createComputedSetterForItemField("date_acquired"),
+    DateAcquired: createComputedSetterForItemField("date"),
     DateOpened: createComputedSetterForItemField("date_opened"),
     ChemForm: createComputedSetterForItemField("chemform"),
     Supplier: createComputedSetterForItemField("supplier"),

--- a/webapp/src/components/StartingMaterialTable.vue
+++ b/webapp/src/components/StartingMaterialTable.vue
@@ -33,7 +33,7 @@
         </td>
         <td>{{ item.name }}</td>
         <td><ChemicalFormula :formula="item.chemform" /></td>
-        <td>{{ $filters.IsoDatetimeToDate(item.date_acquired) }}</td>
+        <td>{{ $filters.IsoDatetimeToDate(item.date) }}</td>
         <td>{{ item.chemical_purity }}</td>
         <td>{{ item.nblocks }}</td>
         <td align="right">

--- a/webapp/src/components/StartingMaterialTable.vue
+++ b/webapp/src/components/StartingMaterialTable.vue
@@ -28,7 +28,6 @@
             :item_id="item.item_id"
             :itemType="item?.type || 'starting_materials'"
             enableModifiedClick
-            :maxLength="formattedItemNameMaxLength"
           />
         </td>
         <td>{{ item.name }}</td>

--- a/webapp/src/components/StartingMaterialTable.vue
+++ b/webapp/src/components/StartingMaterialTable.vue
@@ -12,6 +12,7 @@
         <th scope="col">Date acquired</th>
         <th scope="col">Purity</th>
         <th scope="col"># of blocks</th>
+        <th scope="col"></th>
       </tr>
     </thead>
     <tbody>
@@ -35,6 +36,11 @@
         <td>{{ $filters.IsoDatetimeToDate(item.date_acquired) }}</td>
         <td>{{ item.chemical_purity }}</td>
         <td>{{ item.nblocks }}</td>
+        <td align="right">
+          <button type="button" class="close" @click.stop="deleteItem(item)" aria-label="delete">
+            <span aria-hidden="true" style="color: grey">&times;</span>
+          </button>
+        </td>
       </tr>
     </tbody>
   </table>
@@ -43,7 +49,7 @@
 <script>
 import ChemicalFormula from "@/components/ChemicalFormula";
 import FormattedItemName from "@/components/FormattedItemName";
-import { getStartingMaterialList } from "@/server_fetch_utils.js";
+import { getStartingMaterialList, deleteStartingMaterial } from "@/server_fetch_utils.js";
 
 export default {
   data() {
@@ -67,6 +73,13 @@ export default {
       getStartingMaterialList().catch(() => {
         this.isFetchError = true;
       });
+    },
+    deleteItem(item) {
+      if (confirm(`Are you sure you want to delete starting material "${item.item_id}"?`)) {
+        console.log("deleting...");
+        deleteStartingMaterial(item.item_id);
+      }
+      console.log("delete cancelled.");
     },
   },
   created() {

--- a/webapp/src/components/StyledInput.vue
+++ b/webapp/src/components/StyledInput.vue
@@ -1,0 +1,39 @@
+<template>
+  <input
+    :type="type"
+    :class="{ 'form-control': !readonly, 'form-control-plaintext': readonly }"
+    :readonly="readonly"
+    v-model="vmodelvalue"
+  />
+</template>
+
+<script>
+// This component is a simple wrapper of <input> that allows for
+// proper bootstrap styling when 'readonly' is applied. It also
+// allows 'date' inputs to work even if datetime strings are supplied
+// (but, the time is discarded!)
+
+export default {
+  props: {
+    modelValue: { default: "" },
+    readonly: {
+      type: Boolean,
+      default: false,
+    },
+    type: { default: "string" },
+  },
+  computed: {
+    vmodelvalue: {
+      get() {
+        if (this.type == "date") {
+          return this.modelValue && this.modelValue.split("T")[0];
+        }
+        return this.modelValue;
+      },
+      set(value) {
+        this.$emit("update:modelValue", value);
+      },
+    },
+  },
+};
+</script>

--- a/webapp/src/components/StyledInput.vue
+++ b/webapp/src/components/StyledInput.vue
@@ -1,6 +1,6 @@
 <template>
   <input
-    :type="type"
+    :type="inputType"
     :class="{ 'form-control': !readonly, 'form-control-plaintext': readonly }"
     :readonly="readonly"
     v-model="vmodelvalue"
@@ -23,6 +23,12 @@ export default {
     type: { default: "string" },
   },
   computed: {
+    inputType() {
+      if (this.readonly && (this.type == "date" || this.type == "datetime-local")) {
+        return "text";
+      }
+      return this.type;
+    },
     vmodelvalue: {
       get() {
         if (this.type == "date") {

--- a/webapp/src/resources.js
+++ b/webapp/src/resources.js
@@ -27,7 +27,10 @@ export const HOMEPAGE_URL = process.env.VUE_APP_HOMEPAGE_URL;
 
 export const GRAVATAR_STYLE = "identicon";
 
-export const IS_STARTING_MATERIAL_EDITABLE = true;
+// determine whether inventory should be readonly (except blocks). Note: environment
+// variables can only be strings, not bools.
+const editable_inventory = process.env.VUE_APP_EDITABLE_INVENTORY || "false";
+export const EDITABLE_INVENTORY = editable_inventory.toLowerCase() == "true";
 
 export const UPPY_MAX_TOTAL_FILE_SIZE =
   Number(process.env.VUE_APP_UPPY_MAX_TOTAL_FILE_SIZE) != null

--- a/webapp/src/resources.js
+++ b/webapp/src/resources.js
@@ -24,7 +24,10 @@ export const API_TOKEN = process.env.VUE_APP_API_TOKEN;
 
 export const LOGO_URL = process.env.VUE_APP_LOGO_URL;
 export const HOMEPAGE_URL = process.env.VUE_APP_HOMEPAGE_URL;
+
 export const GRAVATAR_STYLE = "identicon";
+
+export const IS_STARTING_MATERIAL_EDITABLE = true;
 
 export const UPPY_MAX_TOTAL_FILE_SIZE =
   Number(process.env.VUE_APP_UPPY_MAX_TOTAL_FILE_SIZE) != null

--- a/webapp/src/resources.js
+++ b/webapp/src/resources.js
@@ -100,6 +100,9 @@ export const itemTypes = {
   },
 };
 
+export const SAMPLE_TABLE_TYPES = ["samples", "cells"];
+export const INVENTORY_TABLE_TYPES = ["starting_materials"];
+
 export const cellFormats = {
   coin: "coin",
   pouch: "pouch",

--- a/webapp/src/resources.js
+++ b/webapp/src/resources.js
@@ -12,9 +12,10 @@ import MassSpecBlock from "@/components/datablocks/MassSpecBlock";
 import SampleInformation from "@/components/SampleInformation";
 import StartingMaterialInformation from "@/components/StartingMaterialInformation";
 import CellInformation from "@/components/CellInformation";
+import CollectionInformation from "@/components/CollectionInformation";
+
 import SampleCreateModalAddon from "@/components/itemCreateModalAddons/SampleCreateModalAddon";
 import CellCreateModalAddon from "@/components/itemCreateModalAddons/CellCreateModalAddon";
-import CollectionInformation from "@/components/CollectionInformation";
 
 // Look for values set in .env file. Use defaults if `null` is not explicitly handled elsewhere in the code.
 export const API_URL =
@@ -65,7 +66,7 @@ export const itemTypes = {
     navbarName: "Starting Material",
     lightColor: "#d9f2eb",
     labelColor: "#298651",
-    isCreateable: false,
+    isCreateable: true,
     display: "starting material",
   },
   cells: {

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -290,6 +290,17 @@ export function deleteSample(item_id) {
     .catch((error) => alert("Sample delete failed for " + item_id + ": " + error));
 }
 
+export function deleteStartingMaterial(item_id) {
+  return fetch_post(`${API_URL}/delete-sample/`, {
+    item_id: item_id,
+  })
+    .then(function (response_json) {
+      console.log("delete successful" + response_json);
+      store.commit("deleteFromStartingMaterialList", item_id);
+    })
+    .catch((error) => alert("Item delete failed for " + item_id + ": " + error));
+}
+
 export function deleteCollection(collection_id, collection_summary) {
   return fetch_delete(`${API_URL}/collections/${collection_id}`)
     .then(function (response_json) {

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -2,7 +2,7 @@
 // all code using fetch should be collected into this file
 
 import store from "@/store/index.js";
-import { API_URL, API_TOKEN } from "@/resources.js";
+import { API_URL, API_TOKEN, SAMPLE_TABLE_TYPES, INVENTORY_TABLE_TYPES } from "@/resources.js";
 
 // ****************************************************************************
 // A simple wrapper to simplify response handling for fetch calls
@@ -115,8 +115,15 @@ export function createNewItem(
   }).then(function (response_json) {
     console.log("received the following data from fetch new-sample:");
     console.log(response_json.sample_list_entry);
-    console.log(`item_id: ${item_id}`);
-    store.commit("prependToSampleList", response_json.sample_list_entry);
+    console.log(
+      `created a new item with item_id: ${item_id}, type: ${response_json.sample_list_entry.type}`,
+    );
+    if (SAMPLE_TABLE_TYPES.includes(response_json.sample_list_entry.type)) {
+      store.commit("prependToSampleList", response_json.sample_list_entry);
+    }
+    if (INVENTORY_TABLE_TYPES.includes(response_json.sample_list_entry.type)) {
+      store.commit("prependToStartingMaterialList", response_json.sample_list_entry);
+    }
     return "success";
   });
 }

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -67,6 +67,14 @@ export default createStore({
         console.log(`deleteFromSampleList couldn't find the item with id ${item_id}`);
       }
     },
+    deleteFromStartingMaterialList(state, item_id) {
+      const index = state.starting_material_list.map((e) => e.item_id).indexOf(item_id);
+      if (index > -1) {
+        state.starting_material_list.splice(index, 1);
+      } else {
+        console.log(`deleteFromStartingMaterialList couldn't find the item with id ${item_id}`);
+      }
+    },
     deleteFromCollectionList(state, collection_summary) {
       const index = state.collection_list.indexOf(collection_summary);
       if (index > -1) {

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -51,6 +51,10 @@ export default createStore({
       // sampleSummary is a json object summarizing the new sample
       state.sample_list.unshift(sampleSummary);
     },
+    prependToStartingMaterialList(state, itemSummary) {
+      // sampleSummary is a json object summarizing the new sample
+      state.starting_material_list.unshift(itemSummary);
+    },
     prependToCollectionList(state, collectionSummary) {
       // collectionSummary is a json object summarizing the new collection
       state.collection_list.unshift(collectionSummary);

--- a/webapp/src/views/Samples.vue
+++ b/webapp/src/views/Samples.vue
@@ -4,7 +4,7 @@
   <div id="tableContainer" class="container">
     <div class="row">
       <div class="col-sm-12 mx-auto mb-3">
-        <button class="btn btn-default" @click="createSampleModalIsOpen = true">Add an item</button>
+        <button class="btn btn-default" @click="createItemModalIsOpen = true">Add an item</button>
         <button class="btn btn-default ml-2" @click="batchCreateSampleModalIsOpen = true">
           Add batch of samples
         </button>
@@ -16,28 +16,28 @@
       </div>
     </div>
   </div>
-  <CreateSampleModal v-model="createSampleModalIsOpen" />
+  <CreateItemModal v-model="createItemModalIsOpen" />
   <BatchCreateSampleModal v-model="batchCreateSampleModalIsOpen" />
 </template>
 
 <script>
 import Navbar from "@/components/Navbar";
 import SampleTable from "@/components/SampleTable";
-import CreateSampleModal from "@/components/CreateSampleModal";
+import CreateItemModal from "@/components/CreateItemModal";
 import BatchCreateSampleModal from "@/components/BatchCreateSampleModal";
 
 export default {
   name: "Samples",
   data() {
     return {
-      createSampleModalIsOpen: false,
+      createItemModalIsOpen: false,
       batchCreateSampleModalIsOpen: false,
     };
   },
   components: {
     Navbar,
     SampleTable,
-    CreateSampleModal,
+    CreateItemModal,
     BatchCreateSampleModal,
   },
 };

--- a/webapp/src/views/Samples.vue
+++ b/webapp/src/views/Samples.vue
@@ -16,7 +16,7 @@
       </div>
     </div>
   </div>
-  <CreateItemModal v-model="createItemModalIsOpen" />
+  <CreateItemModal v-model="createItemModalIsOpen" :allowedTypes="allowedTypes" />
   <BatchCreateSampleModal v-model="batchCreateSampleModalIsOpen" />
 </template>
 
@@ -25,6 +25,7 @@ import Navbar from "@/components/Navbar";
 import SampleTable from "@/components/SampleTable";
 import CreateItemModal from "@/components/CreateItemModal";
 import BatchCreateSampleModal from "@/components/BatchCreateSampleModal";
+import { SAMPLE_TABLE_TYPES } from "@/resources.js";
 
 export default {
   name: "Samples",
@@ -32,6 +33,7 @@ export default {
     return {
       createItemModalIsOpen: false,
       batchCreateSampleModalIsOpen: false,
+      allowedTypes: SAMPLE_TABLE_TYPES,
     };
   },
   components: {

--- a/webapp/src/views/SamplesNext.vue
+++ b/webapp/src/views/SamplesNext.vue
@@ -4,7 +4,7 @@
   <div id="tableContainer" class="container">
     <div class="row">
       <div class="col-sm-12 mx-auto mb-3">
-        <button class="btn btn-default" @click="createSampleModalIsOpen = true">Add an item</button>
+        <button class="btn btn-default" @click="createItemModalIsOpen = true">Add an item</button>
         <button class="btn btn-default ml-2" @click="batchCreateSampleModalIsOpen = true">
           Add batch of samples
         </button>
@@ -16,28 +16,28 @@
       </div>
     </div>
   </div>
-  <CreateSampleModal v-model="createSampleModalIsOpen" />
+  <CreateItemModal v-model="createItemModalIsOpen" />
   <BatchCreateSampleModal v-model="batchCreateSampleModalIsOpen" />
 </template>
 
 <script>
 import Navbar from "@/components/Navbar";
 import FancySampleTable from "@/components/FancySampleTable";
-import CreateSampleModal from "@/components/CreateSampleModal";
+import CreateItemModal from "@/components/CreateItemModal";
 import BatchCreateSampleModal from "@/components/BatchCreateSampleModal";
 
 export default {
   name: "Samples",
   data() {
     return {
-      createSampleModalIsOpen: false,
+      createItemModalIsOpen: false,
       batchCreateSampleModalIsOpen: false,
     };
   },
   components: {
     Navbar,
     FancySampleTable,
-    CreateSampleModal,
+    CreateItemModal,
     BatchCreateSampleModal,
   },
 };

--- a/webapp/src/views/StartingMaterials.vue
+++ b/webapp/src/views/StartingMaterials.vue
@@ -3,7 +3,11 @@
   <div id="tableContainer" class="container">
     <div class="row">
       <div class="col-sm-12 mx-auto mb-3">
-        <button class="btn btn-default" @click="createItemModalIsOpen = true">
+        <button
+          v-if="editable_inventory"
+          class="btn btn-default"
+          @click="createItemModalIsOpen = true"
+        >
           Add a starting material
         </button>
       </div>
@@ -21,7 +25,7 @@
 import Navbar from "@/components/Navbar";
 import StartingMaterialTable from "@/components/StartingMaterialTable";
 import CreateItemModal from "@/components/CreateItemModal";
-import { INVENTORY_TABLE_TYPES } from "@/resources.js";
+import { INVENTORY_TABLE_TYPES, EDITABLE_INVENTORY } from "@/resources.js";
 
 export default {
   name: "StartingMaterials",
@@ -35,6 +39,9 @@ export default {
     Navbar,
     StartingMaterialTable,
     CreateItemModal,
+  },
+  created() {
+    this.editable_inventory = EDITABLE_INVENTORY;
   },
 };
 </script>

--- a/webapp/src/views/StartingMaterials.vue
+++ b/webapp/src/views/StartingMaterials.vue
@@ -2,21 +2,59 @@
   <Navbar />
   <div id="tableContainer" class="container">
     <div class="row">
-      <div class="col-sm-10 mx-auto">
+      <div class="col-sm-12 mx-auto mb-3">
+        <button class="btn btn-default" @click="createItemModalIsOpen = true">
+          Add a starting material
+        </button>
+      </div>
+    </div>
+    <div class="row">
+      <div class="col-sm-12 mx-auto">
         <StartingMaterialTable></StartingMaterialTable>
       </div>
     </div>
   </div>
+  <CreateItemModal v-model="createItemModalIsOpen" />
 </template>
 
 <script>
 import Navbar from "@/components/Navbar";
 import StartingMaterialTable from "@/components/StartingMaterialTable";
+import CreateItemModal from "@/components/CreateItemModal";
 
 export default {
+  name: "StartingMaterials",
+  data() {
+    return {
+      createItemModalIsOpen: false,
+    };
+  },
   components: {
     Navbar,
     StartingMaterialTable,
+    CreateItemModal,
   },
 };
 </script>
+
+<style scoped>
+.fade {
+  opacity: 0;
+  transition: opacity 0.15s linear;
+}
+.fade.show {
+  opacity: 1;
+}
+
+#tableContainer.overlay:after {
+  content: "";
+  display: block;
+  position: fixed; /* could also be absolute */
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  z-index: 10;
+  background-color: rgba(0, 0, 0, 0.2);
+}
+</style>

--- a/webapp/src/views/StartingMaterials.vue
+++ b/webapp/src/views/StartingMaterials.vue
@@ -14,19 +14,21 @@
       </div>
     </div>
   </div>
-  <CreateItemModal v-model="createItemModalIsOpen" />
+  <CreateItemModal v-model="createItemModalIsOpen" :allowedTypes="allowedTypes" />
 </template>
 
 <script>
 import Navbar from "@/components/Navbar";
 import StartingMaterialTable from "@/components/StartingMaterialTable";
 import CreateItemModal from "@/components/CreateItemModal";
+import { INVENTORY_TABLE_TYPES } from "@/resources.js";
 
 export default {
   name: "StartingMaterials",
   data() {
     return {
       createItemModalIsOpen: false,
+      allowedTypes: INVENTORY_TABLE_TYPES,
     };
   },
   components: {


### PR DESCRIPTION
- [x] Add "Create Item" Modal to Sample table page
- [x] Make backend tweaks to allow Starting Materials to be added from the app
- [x] Make starting material fields editable in the frontent (dependent on a configuration variable)
- [x]  Refactor `<inputs>` to a custom `<EditableInput>` field, which will clean up the code and make it easier to do read-only versions of other items in the future
- [x] Add ability to filter types allowed in `CreateItemModal.vue`
- [x] Additional field: CAS, hazards

Also closes #648 and closes #654