### PR TITLE
Fix typo where CI tests were never run in chrome

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,7 +166,7 @@ jobs:
           spec: |
             ./cypress/e2e/sampleTablePage.cy.js
             ./cypress/e2e/editPage.cy.js
-          browser: "electron"
+          browser: "chrome"
         env:
           CYPRESS_RECORD_KEY: ${{ secrets.CYPRESS_RECORD_KEY }}
 


### PR DESCRIPTION
This is simply an oversight. If the tests pass I will merge.

Sadly I don't think the docker cache is being used during builds anymore, but I don't have the energy or wherewithal to go down that undocumented rabbit hole again.