### PR TITLE
Allow echem block to plot non-cyclic data

### DIFF
--- a/pydatalab/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/pydatalab/apps/echem/blocks.py
@@ -134,15 +134,21 @@ class CycleBlock(DataBlock):
                 raise RuntimeError(f"Navani raised an error when parsing: {exc}") from exc
             raw_df.to_pickle(parsed_file_loc)
 
-        if cycle_summary_df is None:
-            cycle_summary_df = ec.cycle_summary(raw_df)
-            cycle_summary_df.to_pickle(cycle_summary_file_loc)
+        try:
+            if cycle_summary_df is None:
+                cycle_summary_df = ec.cycle_summary(raw_df)
+                cycle_summary_df.to_pickle(cycle_summary_file_loc)
+        except Exception:
+            pass
 
         raw_df = raw_df.filter(required_keys)
         raw_df.rename(columns=keys_with_units, inplace=True)
 
-        cycle_summary_df.rename(columns=keys_with_units, inplace=True)
-        cycle_summary_df["cycle index"] = pd.to_numeric(cycle_summary_df.index, downcast="integer")
+        if cycle_summary_df is not None:
+            cycle_summary_df.rename(columns=keys_with_units, inplace=True)
+            cycle_summary_df["cycle index"] = pd.to_numeric(
+                cycle_summary_df.index, downcast="integer"
+            )
 
         return raw_df, cycle_summary_df
 


### PR DESCRIPTION
Currently we always try to compute cycle summaries on echem data. This fails when there is no `state` in the data, indicating when a cycle starts/ends. For e.g., linear/sweep voltammetry this data is not available, but we can still easily read the files and make useful plots. This PR simply ignores any errors from the navani summariser (for now) and lets the UI still plot whatever data is available.

Ideally we'd add some error checking in navani itself that handles this in a nicer way.

Closes #664 