### PR TITLE
Improve block warning/error reactivity in the UI

### DIFF
--- a/pydatalab/pydatalab/apps/echem/blocks.py
+++ b/pydatalab/pydatalab/apps/echem/blocks.py
@@ -217,9 +217,12 @@ class CycleBlock(DataBlock):
             df, cycle_summary=cycle_summary_df, mode=mode, normalized=bool(characteristic_mass_g)
         )
 
-        self.data["bokeh_plot_data"] = bokeh.embed.json_item(
-            layout, theme=bokeh_plots.DATALAB_BOKEH_THEME
-        )
+        if layout is not None:
+            # Don't overwrite the previous plot data in cases where the plot is not generated
+            # for a 'normal' reason
+            self.data["bokeh_plot_data"] = bokeh.embed.json_item(
+                layout, theme=bokeh_plots.DATALAB_BOKEH_THEME
+            )
         return
 
     @property

--- a/pydatalab/pydatalab/blocks/base.py
+++ b/pydatalab/pydatalab/blocks/base.py
@@ -152,10 +152,15 @@ class DataBlock:
                                 ]
                             )
 
+        # If the last plotting run did not raise any errors or warnings, remove any old ones
         if block_errors:
             self.data["errors"] = block_errors
+        else:
+            self.data.pop("errors", None)
         if block_warnings:
             self.data["warnings"] = block_warnings
+        else:
+            self.data.pop("warnings", None)
 
         return self.data
 

--- a/pydatalab/pydatalab/bokeh_plots.py
+++ b/pydatalab/pydatalab/bokeh_plots.py
@@ -364,6 +364,7 @@ def double_axes_echem_plot(
     # x_label = "Capacity (mAh/g)" if x_default == "Capacity normalized" else x_default
     x_label = x_default
     p1 = figure(x_axis_label=x_label, y_axis_label="voltage (V)", **common_options)
+    p1.xaxis.ticker.desired_num_ticks = 5
     plots.append(p1)
 
     # the differential plot
@@ -375,10 +376,12 @@ def double_axes_echem_plot(
                 y_range=p1.y_range,
                 **common_options,
             )
+            p2.xaxis.ticker.desired_num_ticks = 3
         else:
             p2 = figure(
                 x_axis_label=x_default, y_axis_label=mode, x_range=p1.x_range, **common_options
             )
+            p2.xaxis.ticker.desired_num_ticks = 5
         plots.append(p2)
 
     elif mode == "final capacity" and cycle_summary is not None:
@@ -431,6 +434,7 @@ def double_axes_echem_plot(
 
         p3.legend.location = "right"
         p3.y_range.start = 0
+        p3.xaxis.ticker.desired_num_ticks = 5
 
     lines = []
     grouped_by_half_cycle = df.groupby("half cycle")

--- a/pydatalab/pydatalab/bokeh_plots.py
+++ b/pydatalab/pydatalab/bokeh_plots.py
@@ -1,3 +1,4 @@
+import warnings
 from typing import Dict, List, Optional, Sequence, Union
 
 import matplotlib
@@ -524,6 +525,9 @@ def double_axes_echem_plot(
     elif mode == "dV/dQ":
         grid = [[p1], [p2]]
     elif mode == "final capacity":
+        if cycle_summary is None:
+            warnings.warn("Unable to generate cycle summary plot for this dataset.")
+            return None
         grid = [[p3]]
     else:
         grid = [[p1], [xaxis_select], [yaxis_select]]

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -156,6 +156,13 @@ export default createStore({
         state.all_item_data[payload.item_id]["blocks_obj"][payload.block_id],
         payload.block_data,
       );
+      // if there are no block warnings or errors, make sure they are not in the store
+      if (!payload.block_data.errors) {
+        delete state.all_item_data[payload.item_id]["blocks_obj"][payload.block_id].errors;
+      }
+      if (!payload.block_data.warnings) {
+        delete state.all_item_data[payload.item_id]["blocks_obj"][payload.block_id].warnings;
+      }
       state.saved_status_blocks[payload.block_id] = false;
     },
     updateItemData(state, payload) {


### PR DESCRIPTION
This PR converts the cycle summary error from #665 into a warning, and makes sure that such warnings disappear when they are no longer valid in the UI.

This required a bit of manual UI hack, but probably fine for now.