### PR TITLE
Add option to generate ID automatically when creating items 

### DIFF
--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -455,8 +455,6 @@ def _create_sample(
             "an automatic item_id was generated for the new sample: {new_sample['item_id']}"
         )
 
-    # import pdb; pdb.set_trace()
-
     # check to make sure that item_id isn't taken already
     if flask_mongo.db.items.find_one({"item_id": sample_dict["item_id"]}):
         return (
@@ -533,9 +531,9 @@ def create_sample():
     request_json = request.get_json()  # noqa: F821 pylint: disable=undefined-variable
     if "new_sample_data" in request_json:
         response, http_code = _create_sample(
-            request_json["new_sample_data"],
-            request_json.get("copy_from_item_id"),
-            request_json.get("generate_id_automatically", False),
+            sample_dict=request_json["new_sample_data"],
+            copy_from_item_id=request_json.get("copy_from_item_id"),
+            generate_id_automatically=request_json.get("generate_id_automatically", False),
         )
     else:
         response, http_code = _create_sample(request_json)
@@ -561,7 +559,11 @@ def create_samples():
         copy_from_item_ids = [None] * len(sample_jsons)
 
     outputs = [
-        _create_sample(sample_json, copy_from_item_id, generate_ids_automatically)
+        _create_sample(
+            sample_dict=sample_json,
+            copy_from_item_id=copy_from_item_id,
+            generate_id_automatically=generate_ids_automatically,
+        )
         for sample_json, copy_from_item_id in zip(sample_jsons, copy_from_item_ids)
     ]
     responses, http_codes = zip(*outputs)

--- a/pydatalab/tests/server/test_startingmaterials.py
+++ b/pydatalab/tests/server/test_startingmaterials.py
@@ -45,6 +45,40 @@ def test_get_item_data(client, default_starting_material_dict):
         assert response.json["item_data"][key] == v
 
 
+@pytest.mark.dependency(depends=["test_new_starting_material", "test_get_item_data"])
+def test_new_sample_with_automatically_generated_id(client):
+    new_starting_material_data = {
+        "name": "sample with random id",
+        "date": datetime.datetime.fromisoformat("1995-03-02"),
+        "date_opened": datetime.datetime.fromisoformat("2001-12-31"),
+        "chemform": "NiO",
+        "type": "starting_materials",
+        "CAS": "1313-99-1",
+    }
+
+    request_json = dict(
+        new_sample_data=new_starting_material_data,
+        generate_id_automatically=True,
+    )
+
+    response = client.post("/new-sample/", json=request_json)
+    # Test that 201: Created is emitted
+    assert response.status_code == 201, response.json
+    assert response.json["status"] == "success"
+    created_item_id = response.json["item_id"]
+    assert created_item_id
+
+    response = client.get(f"/get-item-data/{created_item_id}")
+    assert response.status_code == 200
+    assert response.json["status"] == "success"
+    assert response.json["item_data"]["refcode"].split(":")[1] == created_item_id
+
+    for key in new_starting_material_data.keys():
+        if isinstance(v := new_starting_material_data[key], datetime.datetime):
+            v = v.isoformat()
+        assert response.json["item_data"][key] == v
+
+
 @pytest.mark.dependency(depends=["test_new_starting_material"])
 def test_new_starting_material_collision(client, default_starting_material_dict):
     # Try to do the same thing again, expecting an ID collision

--- a/webapp/cypress/e2e/sampleTablePage.cy.js
+++ b/webapp/cypress/e2e/sampleTablePage.cy.js
@@ -97,6 +97,25 @@ describe("Sample table page", () => {
     );
   });
 
+  it("Adds a sample with an automatic ID", () => {
+    const name = "sample with automatically generated id";
+    const date = "2024-03-26T00:00";
+
+    cy.createSample("irrelevant_id", name, date, true);
+
+    cy.get('[data-testid="sample-table"]')
+      .contains(name)
+      .parents("tr")
+      .within(() => {
+        cy.get("td.table-item-id .formatted-item-name").invoke("text").as("createdId");
+      });
+    cy.get("@createdId").then((createdId) => {
+      expect(createdId).not.to.equal("irrelevant_id");
+      cy.verifySample(createdId, name, date);
+      cy.deleteSample(createdId);
+    });
+  });
+
   it("Adds several valid samples", () => {
     cy.createSample("test1");
     cy.verifySample("test1");

--- a/webapp/cypress/support/commands.js
+++ b/webapp/cypress/support/commands.js
@@ -31,18 +31,26 @@ import "@testing-library/cypress/add-commands";
 const TODAY = new Date().toISOString().slice(0, -8);
 const API_URL = Cypress.config("apiUrl");
 
-Cypress.Commands.add("createSample", (item_id, name = null, date = null) => {
-  cy.findByText("Add an item").click();
-  cy.findByText("Add new item").should("exist");
-  cy.findByLabelText("ID:").type(item_id);
-  if (name) {
-    cy.get("#sample-name").type(name);
-  }
-  if (date) {
-    cy.findByLabelText("Date Created:").type(date);
-  }
-  cy.get("#sample-submit").click();
-});
+Cypress.Commands.add(
+  "createSample",
+  (item_id, name = null, date = null, generate_id_automatically = false) => {
+    cy.findByText("Add an item").click();
+    cy.findByText("Add new item").should("exist");
+    cy.findByLabelText("ID:").type(item_id);
+    if (name) {
+      cy.get("#sample-name").type(name);
+    }
+    if (date) {
+      cy.findByLabelText("Date Created:").type(date);
+    }
+
+    if (generate_id_automatically) {
+      cy.findByLabelText("generate automatically").click();
+    }
+
+    cy.get("#sample-submit").click();
+  },
+);
 
 Cypress.Commands.add("verifySample", (item_id, name = null, date = null) => {
   if (date) {

--- a/webapp/src/components/CreateItemModal.vue
+++ b/webapp/src/components/CreateItemModal.vue
@@ -3,7 +3,9 @@
     <Modal
       :modelValue="modelValue"
       @update:modelValue="$emit('update:modelValue', $event)"
-      :disableSubmit="Boolean(itemIDValidationMessage) || !Boolean(item_id)"
+      :disableSubmit="
+        Boolean(itemIDValidationMessage) || (!generateIDAutomatically && !Boolean(item_id))
+      "
       submitID="sample-submit"
     >
       <template v-slot:header> Add new item </template>
@@ -12,8 +14,30 @@
         <div class="form-row">
           <div class="form-group col-md-6">
             <label for="item-id" class="col-form-label">ID:</label>
-            <input v-model="item_id" type="text" class="form-control" id="item-id" required />
+            <input
+              v-model="item_id"
+              type="text"
+              class="form-control"
+              id="item-id"
+              :disabled="generateIDAutomatically"
+              :required="!generateIDAutomatically"
+            />
             <div class="form-error" v-html="itemIDValidationMessage"></div>
+            <div class="form-check mt-1 ml-1">
+              <input
+                type="checkbox"
+                v-model="generateIDAutomatically"
+                class="form-check-input clickable"
+                id="automatic-id-checkbox"
+                @input="item_id = null"
+              />
+              <label
+                id="automatic-id-label"
+                class="form-check-label clickable"
+                for="automatic-id-checkbox"
+                >generate automatically</label
+              >
+            </div>
           </div>
           <div class="form-group col-md-6">
             <label for="item-type-select" class="col-form-label">Type:</label>
@@ -23,7 +47,7 @@
               </option>
             </select>
           </div>
-          <div class="form-group col-md-6">
+          <div class="form-group col-md-6 pt-0">
             <label for="date" class="col-form-label">Date Created:</label>
             <input
               type="datetime-local"
@@ -100,6 +124,7 @@ export default {
       takenItemIds: [], // this holds ids that have been tried, whereas the computed takenSampleIds holds ids in the sample table
       selectedItemToCopy: null,
       startingConstituents: [],
+      generateIDAutomatically: false,
       agesAgo: new Date("1970-01-01").toISOString().slice(0, -8), // a datetime for the unix epoch start
     };
   },
@@ -169,10 +194,14 @@ export default {
         startingCollection,
         extraData,
         this.selectedItemToCopy && this.selectedItemToCopy.item_id,
+        this.generateIDAutomatically,
       )
         .then(() => {
           this.$emit("update:modelValue", false); // close this modal
-          document.getElementById(this.item_id).scrollIntoView({ behavior: "smooth" });
+          // can enable the following line to get smooth scrolling into view, but will fail
+          // if generateIDAutomatically. It's currently not necessary because
+          // new items always show up at the top of the sample table
+          // // document.getElementById(this.item_id).scrollIntoView({ behavior: "smooth" });
           this.item_id = null;
           this.name = null;
           this.date = this.now(); // reset date to the new current time
@@ -223,6 +252,10 @@ export default {
 </script>
 
 <style scoped>
+#automatic-id-label {
+  color: #555;
+}
+
 .form-error {
   color: red;
 }

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -101,9 +101,11 @@ export function createNewItem(
   startingCollection = null,
   startingData = {},
   copyFrom = null,
+  generateIDAutomatically = false,
 ) {
   return fetch_post(`${API_URL}/new-sample/`, {
     copy_from_item_id: copyFrom,
+    generate_id_automatically: generateIDAutomatically,
     new_sample_data: {
       item_id: item_id,
       date: date,
@@ -128,10 +130,15 @@ export function createNewItem(
   });
 }
 
-export function createNewSamples(newSampleDatas, copyFromItemIds = null) {
+export function createNewSamples(
+  newSampleDatas,
+  copyFromItemIds = null,
+  generateIDsAutomatically = false,
+) {
   return fetch_post(`${API_URL}/new-samples/`, {
     copy_from_item_ids: copyFromItemIds,
     new_sample_datas: newSampleDatas,
+    generate_ids_automatically: generateIDsAutomatically,
   }).then(function (response_json) {
     console.log("received the following data from fetch new-samples:");
     console.log(response_json);


### PR DESCRIPTION
Closes #643 by adding an option to generate IDs automatically when creating items. If this option is taken, the generated IDs are the same as the refcode, but without the prefix.

This is an updated version of #650, which had gone stale.