### PR TITLE
Debug flaky e2e tests

### DIFF
--- a/webapp/cypress/e2e/sampleTablePage.cy.js
+++ b/webapp/cypress/e2e/sampleTablePage.cy.js
@@ -254,17 +254,18 @@ describe("Advanced sample creation features", () => {
     cy.findByText("Add an item").click();
     cy.findByLabelText("ID:").type("testBcopy_copy");
     cy.findByLabelText("(Optional) Copy from existing sample:").type("testBcopy");
-    cy.get(".vs__dropdown-menu").within(() => {
-      cy.contains(".badge", "testBcopy").click();
+    cy.findByLabelText("(Optional) Copy from existing sample:").within(() => {
+      cy.contains(".vs__dropdown-menu .badge", "testBcopy").click();
     });
 
     cy.findByLabelText("(Optional) Start with constituents:").type("component2");
-    cy.get(".vs__dropdown-menu").within(() => {
-      cy.contains(".badge", "component2").click();
+    cy.findByLabelText("(Optional) Start with constituents:").within(() => {
+      cy.contains(".vs__dropdown-menu .badge", "component2").click();
     });
+
     cy.findByLabelText("(Optional) Start with constituents:").type("component3");
-    cy.get(".vs__dropdown-menu").within(() => {
-      cy.contains(".badge", "component3").click();
+    cy.findByLabelText("(Optional) Start with constituents:").within(() => {
+      cy.contains(".vs__dropdown-menu .badge", "component3").click();
     });
 
     cy.get("#sample-submit").click();


### PR DESCRIPTION
(Hopefully) fixes the main flaky e2e test.

The issue appeared to be due to the async nature of cypress commands. We had the following code, where 3 different ItemSelect fields are interacted with by searching and then clicking. 
```js
cy.findByLabelText("(Optional) Copy from existing sample:").type("testBcopy");
cy.get(".vs__dropdown-menu").within(() => {
  cy.contains(".badge", "testBcopy").click();
});

cy.findByLabelText("(Optional) Start with constituents:").type("component2");
cy.get(".vs__dropdown-menu").within(() => {
  cy.contains(".badge", "component2").click();
});
cy.findByLabelText("(Optional) Start with constituents:").type("component3");
cy.get(".vs__dropdown-menu").within(() => {
  cy.contains(".badge", "component3").click();
});
```

However, these within() blocks are apparently run asynchronously. It takes some time for the vue-select component to query the server after a search is inputted, and in the meantime the code proceeds to the next block. This can (sometimes) cause there to be multiple open vue-select windows at a time, and  `cy.get(".vs__dropdown-menu")` returns all of them, breaking the test. To attempt to fix this, I have put the search for `".vs__dropdown-menu"` into a within() block, so that it is always scoped to only the correct input. 

Closes #507 
