### PR TITLE
Use mocked API keys in API tests to fake different authentication scenarios 

### DIFF
--- a/pydatalab/pydatalab/config.py
+++ b/pydatalab/pydatalab/config.py
@@ -143,8 +143,8 @@ class ServerConfig(BaseSettings):
         description="The path under which to place stored files uploaded to the server.",
     )
 
-    LOG_FILE: Union[str, Path] = Field(
-        Path(__file__).parent.joinpath("../logs/datalab.log").resolve(),
+    LOG_FILE: str | Path | None = Field(
+        None,
         description="The path to the log file to use for the server and all associated processes (e.g., invoke tasks)",
     )
 
@@ -282,6 +282,8 @@ its importance when deploying a datalab instance.""",
     @validator("LOG_FILE")
     def make_missing_log_directory(cls, v):
         """Make sure that the log directory exists and is writable."""
+        if v is None:
+            return v
         try:
             v = Path(v)
             v.parent.mkdir(exist_ok=True, parents=True)

--- a/pydatalab/pydatalab/logger.py
+++ b/pydatalab/pydatalab/logger.py
@@ -53,12 +53,15 @@ def setup_log(log_name: str = "pydatalab", log_level: Optional[int] = None) -> l
     logger.propagate = False
     stream_handler = AnsiColorHandler()
     stream_handler.setFormatter(logging.Formatter(LOG_FORMAT_STRING))
-    rotating_file_handler = logging.handlers.RotatingFileHandler(
-        CONFIG.LOG_FILE, maxBytes=1000000, backupCount=100
-    )
-    rotating_file_handler.setFormatter(logging.Formatter(LOG_FORMAT_STRING))
     logger.addHandler(stream_handler)
-    logger.addHandler(rotating_file_handler)
+
+    if CONFIG.LOG_FILE is not None:
+        rotating_file_handler = logging.handlers.RotatingFileHandler(
+            CONFIG.LOG_FILE, maxBytes=1000000, backupCount=100
+        )
+        rotating_file_handler.setFormatter(logging.Formatter(LOG_FORMAT_STRING))
+        logger.addHandler(rotating_file_handler)
+
     if log_level is None:
         log_level = logging.INFO
 

--- a/pydatalab/pydatalab/main.py
+++ b/pydatalab/pydatalab/main.py
@@ -113,7 +113,7 @@ def create_app(
     app.config.update(CONFIG.dict())
 
     # This value will still be overwritten by any dotenv values
-    app.config["MAIL_DEBUG"] = CONFIG.TESTING
+    app.config["MAIL_DEBUG"] = app.config.get("MAIL_DEBUG") or CONFIG.TESTING
 
     # percolate datalab mail settings up to the `MAIL_` env vars/app config
     # for use by Flask Mail

--- a/pydatalab/pydatalab/mongo.py
+++ b/pydatalab/pydatalab/mongo.py
@@ -155,6 +155,7 @@ def create_default_indices(
             ("identities.identity_type", pymongo.ASCENDING),
         ],
         unique=True,
+        partialFilterExpression={"identities": {"$exists": True}},
         name="unique user identifiers",
         background=background,
     )

--- a/pydatalab/pydatalab/routes/v0_1/info.py
+++ b/pydatalab/pydatalab/routes/v0_1/info.py
@@ -110,6 +110,6 @@ def get_stats():
 
 
 ENDPOINTS: Dict[str, Callable] = {
-    "/info/": get_info,
+    "/info": get_info,
     "/info/stats": get_stats,
 }

--- a/pydatalab/tests/conftest.py
+++ b/pydatalab/tests/conftest.py
@@ -11,7 +11,7 @@ def fixture_default_filepath():
 
 
 @pytest.fixture(scope="module", name="insert_default_sample")
-def fixture_insert_default_sample(client, default_sample):  # pylint: disable=unused-argument
+def fixture_insert_default_sample(client, default_sample, admin_user_id, user_id):  # pylint: disable=unused-argument
     from pydatalab.mongo import flask_mongo
 
     flask_mongo.db.items.insert_one(default_sample.dict(exclude_unset=False))

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -79,6 +79,8 @@ def app_config(tmp_path_factory):
             "MAIL_DEFAULT_SENDER": "test@example.org",
         },
         "EMAIL_DOMAIN_ALLOW_LIST": ["example.org", "ml-evs.science"],
+        "MAIL_DEBUG": True,
+        "MAIL_SUPPRESS_SEND": True,
     }
 
 
@@ -123,6 +125,7 @@ def app(real_mongo_client, monkeypatch_session, app_config):
             monkeypatch_session.setattr(pydatalab.mongo, "get_database", mock_mongo_database)
 
     app = create_app(app_config)
+
     yield app
     if mongo_cli:
         mongo_cli.drop_database(TEST_DATABASE_NAME)
@@ -154,6 +157,13 @@ def client(app, user_api_key):
 
     app.test_client_class = AuthorizedTestClient
 
+    with app.test_client() as cli:
+        yield cli
+
+
+@pytest.fixture(scope="module")
+def unauthenticated_client(app):
+    """Returns an unauthenticated test client for the API."""
     with app.test_client() as cli:
         yield cli
 

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -279,7 +279,7 @@ def fixture_default_collection():
 
 
 @pytest.fixture(scope="module", name="default_starting_material")
-def fixture_default_starting_material():
+def fixture_default_starting_material(admin_user_id):
     return StartingMaterial(
         **{
             "item_id": "test_sm",
@@ -292,6 +292,7 @@ def fixture_default_starting_material():
             "location": "SR1 room 22",
             "GHS_codes": "H303, H316, H319",
             "type": "starting_materials",
+            "creator_ids": [admin_user_id],
         }
     )
 
@@ -313,7 +314,7 @@ def fixture_default_equipment():
 
 
 @pytest.fixture(scope="module", name="complicated_sample")
-def fixture_complicated_sample():
+def fixture_complicated_sample(user_id):
     from pydatalab.models.samples import Constituent
 
     return Sample(
@@ -323,6 +324,7 @@ def fixture_complicated_sample():
             "date": "1970-02-01",
             "chemform": "Na3P",
             "type": "samples",
+            "creator_ids": [user_id],
             "synthesis_constituents": [
                 Constituent(
                     **{
@@ -366,7 +368,7 @@ def fixture_complicated_sample():
 
 
 @pytest.fixture(scope="module")
-def example_items():
+def example_items(user_id):
     return [
         d.dict(exclude_unset=False)
         for d in [
@@ -377,9 +379,17 @@ def example_items():
                     "description": "NaNiO2",
                     "date": "1970-02-01",
                     "refcode": "grey:TEST1",
+                    "creator_ids": [user_id],
                 }
             ),
-            Sample(**{"item_id": "56789", "name": "alice", "date": "1970-02-01"}),
+            Sample(
+                **{
+                    "item_id": "56789",
+                    "name": "alice",
+                    "date": "1970-02-01",
+                    "creator_ids": [user_id],
+                }
+            ),
             Sample(
                 **{
                     "item_id": "sample_1",
@@ -387,6 +397,7 @@ def example_items():
                     "description": "12345",
                     "date": "1970-02-01",
                     "refcode": "grey:TEST2",
+                    "creator_ids": [user_id],
                 }
             ),
             Sample(
@@ -395,6 +406,7 @@ def example_items():
                     "name": "other_sample",
                     "date": "1970-02-01",
                     "refcode": "grey:TEST3",
+                    "creator_ids": [user_id],
                 }
             ),
             StartingMaterial(
@@ -404,6 +416,7 @@ def example_items():
                     "name": "new material",
                     "date": "1970-02-01",
                     "refcode": "grey:TEST4",
+                    "creator_ids": [user_id],
                 }
             ),
             StartingMaterial(
@@ -413,6 +426,7 @@ def example_items():
                     "name": "NaNiO2",
                     "date": "1970-02-01",
                     "refcode": "grey:TEST5",
+                    "creator_ids": [user_id],
                 }
             ),
         ]

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -221,9 +221,15 @@ def insert_demo_admin(app, admin_user_id, admin_api_key, real_mongo_client):
 
 
 @pytest.fixture(scope="module", name="default_sample")
-def fixture_default_sample():
+def fixture_default_sample(admin_user_id, user_id):
     return Sample(
-        **{"item_id": "12345", "name": "other_sample", "date": "1970-02-01", "type": "samples"}
+        **{
+            "item_id": "12345",
+            "name": "other_sample",
+            "date": "1970-02-01",
+            "type": "samples",
+            "creator_ids": [admin_user_id, user_id],
+        }
     )
 
 

--- a/pydatalab/tests/server/test_auth.py
+++ b/pydatalab/tests/server/test_auth.py
@@ -13,9 +13,9 @@ def test_allow_emails():
     assert not _check_email_domain("test@example2.org", ["example.org"])
 
 
-def test_magic_link_account_creation(client, app, database):
+def test_magic_link_account_creation(unauthenticated_client, app, database):
     with app.extensions["mail"].record_messages() as outbox:
-        response = client.post(
+        response = unauthenticated_client.post(
             "/login/magic-link",
             json={"email": "test@ml-evs.science", "referrer": "datalab.example.org"},
         )
@@ -26,21 +26,21 @@ def test_magic_link_account_creation(client, app, database):
     doc = database.magic_links.find_one()
     assert "jwt" in doc
 
-    response = client.get(f"/login/email?token={doc['jwt']}")
+    response = unauthenticated_client.get(f"/login/email?token={doc['jwt']}")
     assert response.status_code == 307
     assert database.users.find_one({"contact_email": "test@ml-evs.science"})
 
 
-def test_magic_links_expected_failures(client, app):
+def test_magic_links_expected_failures(unauthenticated_client, app):
     with app.extensions["mail"].record_messages() as outbox:
-        response = client.post(
+        response = unauthenticated_client.post(
             "/login/magic-link",
             json={"email": "test@ml-evs.science"},
         )
         assert response.status_code == 400
         assert len(outbox) == 0
 
-        response = client.post(
+        response = unauthenticated_client.post(
             "/login/magic-link",
             json={"email": "not_an_email", "referrer": "datalab.example.org"},
         )
@@ -48,7 +48,7 @@ def test_magic_links_expected_failures(client, app):
         assert len(outbox) == 0
         assert response.json["detail"] == "Invalid email provided."
 
-        response = client.post(
+        response = unauthenticated_client.post(
             "/login/magic-link",
             json={"email": "banned_email@gmail.com", "referrer": "datalab.example.org"},
         )

--- a/pydatalab/tests/server/test_equipment.py
+++ b/pydatalab/tests/server/test_equipment.py
@@ -111,8 +111,9 @@ def test_save_good_equipment(client, default_equipment_dict):
 
 
 @pytest.mark.dependency(depends=["test_new_equipment"])
-def test_delete_equipment(client, default_equipment_dict):
-    response = client.post(
+def test_delete_equipment(admin_client, default_equipment_dict):
+    """For now, only admins can delete equipment."""
+    response = admin_client.post(
         "/delete-sample/",
         json={"item_id": default_equipment_dict["item_id"]},
     )
@@ -120,7 +121,7 @@ def test_delete_equipment(client, default_equipment_dict):
     assert response.json["status"] == "success"
 
     # Check it was actually deleted
-    response = client.get(
+    response = admin_client.get(
         f"/get-item-data/{default_equipment_dict['item_id']}",
     )
     assert response.status_code == 404

--- a/pydatalab/tests/server/test_info_and_health.py
+++ b/pydatalab/tests/server/test_info_and_health.py
@@ -3,7 +3,7 @@ import pytest
 
 @pytest.mark.parametrize("url_prefix", ["", "/v0", "/v0.1", "/v0.1.0"])
 def test_info_endpoint(client, url_prefix):
-    response = client.get(f"{url_prefix}/info", follow_redirects=True)
+    response = client.get(f"{url_prefix}/info")
     assert response.status_code == 200
     assert all(k in response.json for k in ("data", "meta", "links"))
     assert all(k in response.json["data"] for k in ("type", "id", "attributes"))
@@ -11,7 +11,7 @@ def test_info_endpoint(client, url_prefix):
 
 @pytest.mark.parametrize("url_prefix", ["", "/v0", "/v0.1", "/v0.1.0"])
 def test_healthcheck_is_alive_endpoint(client, url_prefix):
-    response = client.get(f"{url_prefix}/healthcheck/is_alive", follow_redirects=True)
+    response = client.get(f"{url_prefix}/healthcheck/is_alive")
     assert response.status_code == 200
     assert response.json["status"] == "success"
     assert response.json["message"] == "Server is alive"
@@ -19,7 +19,7 @@ def test_healthcheck_is_alive_endpoint(client, url_prefix):
 
 @pytest.mark.parametrize("url_prefix", ["", "/v0", "/v0.1", "/v0.1.0"])
 def test_healthcheck_is_ready_endpoint(client, url_prefix):
-    response = client.get(f"{url_prefix}/healthcheck/is_ready", follow_redirects=True)
+    response = client.get(f"{url_prefix}/healthcheck/is_ready")
     assert response.status_code == 200
     assert response.json["status"] == "success"
     assert response.json["message"] == "Server and database are ready"

--- a/pydatalab/tests/server/test_samples.py
+++ b/pydatalab/tests/server/test_samples.py
@@ -22,6 +22,8 @@ def test_new_sample(client, default_sample_dict):
     assert response.status_code == 201, response.json
     assert response.json["status"] == "success"
     for key in default_sample_dict.keys():
+        if key == "creator_ids":
+            continue
         if isinstance(v := default_sample_dict[key], datetime.datetime):
             v = v.isoformat()
         assert response.json["sample_list_entry"][key] == v
@@ -33,6 +35,8 @@ def test_get_item_data(client, default_sample_dict):
     assert response.status_code == 200
     assert response.json["status"] == "success"
     for key in default_sample_dict.keys():
+        if key == "creator_ids":
+            continue
         if isinstance(v := default_sample_dict[key], datetime.datetime):
             v = v.isoformat()
         assert response.json["item_data"][key] == v
@@ -50,13 +54,14 @@ def test_new_sample_collision(client, default_sample_dict):
 
 
 @pytest.mark.dependency(depends=["test_new_sample", "test_get_item_data"])
-def test_new_sample_with_automatically_generated_id(client):
+def test_new_sample_with_automatically_generated_id(client, user_id):
     new_sample_data = {
         "name": "sample with random id",
         "date": datetime.datetime.fromisoformat("1995-03-02"),
         "chemform": "H2O",
         "type": "samples",
         "synthesis_description": "2 parts hydrogen were added to 1 part oxygen",
+        "creator_ids": [user_id],
     }
 
     request_json = dict(
@@ -79,6 +84,8 @@ def test_new_sample_with_automatically_generated_id(client):
     for key in new_sample_data.keys():
         if isinstance(v := new_sample_data[key], datetime.datetime):
             v = v.isoformat()
+        if key == "creator_ids":
+            continue
         assert response.json["item_data"][key] == v
 
 

--- a/pydatalab/tests/server/test_starting_materials.py
+++ b/pydatalab/tests/server/test_starting_materials.py
@@ -23,6 +23,8 @@ def test_new_starting_material(client, default_starting_material_dict):
     assert len(response.json["sample_list_entry"]["creators"]) == 0
 
     for key, value in response.json["sample_list_entry"].items():
+        if key == "creator_ids":
+            continue
         if key in default_starting_material_dict:
             if isinstance(v := default_starting_material_dict[key], datetime.datetime):
                 v = v.isoformat()
@@ -30,16 +32,18 @@ def test_new_starting_material(client, default_starting_material_dict):
 
 
 @pytest.mark.dependency(depends=["test_new_starting_material"])
-def test_get_item_data(client, default_starting_material_dict):
-    response = client.get("/get-item-data/test_sm")
+def test_get_item_data(admin_client, default_starting_material_dict):
+    response = admin_client.get("/get-item-data/test_sm")
     assert response.status_code == 200
     assert response.json["status"] == "success"
 
     # all starting materials should have no creators currently (they are shared among a deployment):
     assert len(response.json["item_data"]["creators"]) == 0
     assert len(response.json["item_data"]["creator_ids"]) == 0
-
     for key in default_starting_material_dict.keys():
+        if key == "creator_ids":
+            continue
+
         if isinstance(v := default_starting_material_dict[key], datetime.datetime):
             v = v.isoformat()
         assert response.json["item_data"][key] == v
@@ -74,6 +78,8 @@ def test_new_starting_material_with_automatically_generated_id(client):
     assert response.json["item_data"]["refcode"].split(":")[1] == created_item_id
 
     for key in new_starting_material_data.keys():
+        if key == "creator_ids":
+            continue
         if isinstance(v := new_starting_material_data[key], datetime.datetime):
             v = v.isoformat()
         assert response.json["item_data"][key] == v
@@ -92,10 +98,10 @@ def test_new_starting_material_collision(client, default_starting_material_dict)
 
 
 @pytest.mark.dependency(depends=["test_new_starting_material"])
-def test_save_good_starting_material(client, default_starting_material_dict):
+def test_save_good_starting_material(admin_client, default_starting_material_dict):
     updated_starting_material = default_starting_material_dict.copy()
     updated_starting_material.update({"description": "This is a newer test sample."})
-    response = client.post(
+    response = admin_client.post(
         "/save-item/",
         json={
             "item_id": default_starting_material_dict["item_id"],
@@ -105,7 +111,7 @@ def test_save_good_starting_material(client, default_starting_material_dict):
     assert response.status_code == 200, response.json
     assert response.json["status"] == "success"
 
-    response = client.get("/get-item-data/test_sm")
+    response = admin_client.get("/get-item-data/test_sm")
     assert response.status_code == 200
     assert response.json["status"] == "success"
     for key in default_starting_material_dict.keys():
@@ -113,9 +119,9 @@ def test_save_good_starting_material(client, default_starting_material_dict):
             assert response.json[key] == updated_starting_material[key]
 
 
-@pytest.mark.dependency(depends=["test_new_starting_material"])
-def test_delete_starting_material(client, default_starting_material_dict):
-    response = client.post(
+@pytest.mark.dependency(depends=["test_save_good_starting_material"])
+def test_delete_starting_mateiral(admin_client, default_starting_material_dict):
+    response = admin_client.post(
         "/delete-sample/",
         json={"item_id": default_starting_material_dict["item_id"]},
     )
@@ -123,7 +129,7 @@ def test_delete_starting_material(client, default_starting_material_dict):
     assert response.json["status"] == "success"
 
     # Check it was actually deleted
-    response = client.get(
+    response = admin_client.get(
         f"/get-item-data/{default_starting_material_dict['item_id']}",
     )
     assert response.status_code == 404

--- a/pydatalab/tests/server/test_users.py
+++ b/pydatalab/tests/server/test_users.py
@@ -1,6 +1,13 @@
 from pydatalab.models.people import Person
 
 
+def test_get_current_user(client, insert_demo_user):
+    """Test that the API key for the demo user has been set correctly."""
+
+    resp = client.get("/get-current-user/")
+    assert resp.status_code == 200
+
+
 def test_user_update(client, real_mongo_client):
     example_user = Person(display_name="Test Person", contact_email="test@example.org").dict(
         exclude_unset=True, exclude_none=True

--- a/pydatalab/tests/server/test_users.py
+++ b/pydatalab/tests/server/test_users.py
@@ -1,19 +1,11 @@
-from pydatalab.models.people import Person
-
-
-def test_get_current_user(client, insert_demo_user):
+def test_get_current_user(client):
     """Test that the API key for the demo user has been set correctly."""
 
     resp = client.get("/get-current-user/")
     assert resp.status_code == 200
 
 
-def test_user_update(client, real_mongo_client):
-    example_user = Person(display_name="Test Person", contact_email="test@example.org").dict(
-        exclude_unset=True, exclude_none=True
-    )
-    user_id = real_mongo_client.get_database().users.insert_one(example_user).inserted_id
-
+def test_user_update(client, admin_client, real_mongo_client, user_id, admin_user_id):
     endpoint = f"/users/{str(user_id)}"
 
     # Test display name update
@@ -22,6 +14,13 @@ def test_user_update(client, real_mongo_client):
     assert resp.status_code == 200
     user = real_mongo_client.get_database().users.find_one({"_id": user_id})
     assert user["display_name"] == "Test Person II"
+
+    # Test admin override of display name
+    user_request = {"display_name": "Test Person"}
+    resp = admin_client.patch(endpoint, json=user_request)
+    assert resp.status_code == 200
+    user = real_mongo_client.get_database().users.find_one({"_id": user_id})
+    assert user["display_name"] == "Test Person"
 
     # Test contact email update
     user_request = {"contact_email": "test2@example.org"}
@@ -35,7 +34,7 @@ def test_user_update(client, real_mongo_client):
     resp = client.patch(endpoint, json=user_request)
     assert resp.status_code == 200
     user = real_mongo_client.get_database().users.find_one({"_id": user_id})
-    assert user["display_name"] == "Test Person II"
+    assert user["display_name"] == "Test Person"
 
     # Test that contact_email -> None or empty DOES remove email
     user_request = {"contact_email": None}
@@ -61,7 +60,7 @@ def test_user_update(client, real_mongo_client):
     resp = client.patch(endpoint, json=user_request)
     assert resp.status_code == 400
     user = real_mongo_client.get_database().users.find_one({"_id": user_id})
-    assert user["display_name"] == "Test Person II"
+    assert user["display_name"] == "Test Person"
 
     # Test bad contact email does not update
     user_request = {"contact_email": "not_an_email"}
@@ -69,3 +68,11 @@ def test_user_update(client, real_mongo_client):
     assert resp.status_code == 400
     user = real_mongo_client.get_database().users.find_one({"_id": user_id})
     assert user["contact_email"] is None
+
+    # Test that user cannot update admin account
+    endpoint = f"/users/{str(admin_user_id)}"
+    user_request = {"display_name": "Test Person"}
+    resp = client.patch(endpoint, json=user_request)
+    assert resp.status_code == 403
+    user = real_mongo_client.get_database().users.find_one({"_id": admin_user_id})
+    assert user["display_name"] == "Test Admin"

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -189,7 +189,7 @@ export async function getStats() {
 }
 
 export async function getInfo() {
-  return fetch_get(`${API_URL}/info/`)
+  return fetch_get(`${API_URL}/info`)
     .then(function (response_json) {
       return { apiVersion: response_json.data.attributes.server_version };
     })


### PR DESCRIPTION
As discussed in #203 and #671, this PR begins properly testing authenticated routes and permissions by creating and using fake user accounts during testing. At some point, this could be expanded to the UI tests too.

Closes #203.

We will need to update this at some point once the proper permissions model has been decided upon for equipment and starting materials, as for now I've had to run the inventory/equipment deletion tests with the admin client.