### PR TITLE
Disable codecov PR annotations

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -12,3 +12,5 @@ coverage:
     patch:
       default:
         informational: true
+github_checks:
+  annotations: false


### PR DESCRIPTION
This very annoying feature makes un-coveraged PRs very difficult to review, so let's turn it off for now.