### PR TITLE
Enable ORCID connection by default

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ files/
 uploads/
 ssh_config
 logs/
+site/
 
 # App testing files
 webapp/cypress/screenshots

--- a/pydatalab/pydatalab/errors.py
+++ b/pydatalab/pydatalab/errors.py
@@ -22,9 +22,8 @@ class UserRegistrationForbidden(Forbidden):
 
 <p>
 The OAuth identity used for registration is not on the allow list.
-If you believe this to be an error, please first verify that your membership of the allowed
-group (e.g., a GitHub organization) is public, and verify with the deployment manager that
-the organization is indeed on the allow list.
+If you believe this to be an error, please first verify with the deployment manager
+that you are allowed to make an account.
 </p>
 
 <p>If this was not an error, you may wish to revoke any permissions given to the datalab OAuth application.</p>

--- a/pydatalab/pydatalab/login.py
+++ b/pydatalab/pydatalab/login.py
@@ -54,6 +54,11 @@ class LoginUser(UserMixin):
         return self.person.display_name
 
     @property
+    def contact_email(self) -> Optional[str]:
+        """Returns the top-level display name for the user, if set."""
+        return self.person.contact_email
+
+    @property
     def identities(self) -> List[Identity]:
         """Returns the list of identities of the user."""
         return self.person.identities

--- a/pydatalab/pydatalab/login.py
+++ b/pydatalab/pydatalab/login.py
@@ -55,7 +55,7 @@ class LoginUser(UserMixin):
 
     @property
     def contact_email(self) -> Optional[str]:
-        """Returns the top-level display name for the user, if set."""
+        """Returns the top-level contact email for the user, if set."""
         return self.person.contact_email
 
     @property

--- a/pydatalab/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/pydatalab/routes/v0_1/auth.py
@@ -6,6 +6,7 @@ with their local accounts.
 
 import datetime
 import json
+import os
 import random
 import re
 from hashlib import sha512
@@ -44,7 +45,7 @@ EMAIL_BLUEPRINT = Blueprint("email", __name__)
 AUTH_BLUEPRINTS: Dict[IdentityType, Blueprint] = {
     IdentityType.ORCID: make_orcid_blueprint(
         scope="/authenticate",
-        sandbox=True,
+        sandbox=os.environ.get("OAUTH_ORCID_SANDBOX", False),
     ),
     IdentityType.GITHUB: make_github_blueprint(
         scope="read:org,read:user",

--- a/pydatalab/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/pydatalab/routes/v0_1/auth.py
@@ -35,7 +35,6 @@ LINK_EXPIRATION: datetime.timedelta = datetime.timedelta(hours=1)
 
 @logged_route
 def wrapped_login_user(*args, **kwargs):
-    # LOGGER.warning("Logging in user %s with role %s", args[0].display_name, args[0].role)
     login_user(*args, **kwargs)
 
 
@@ -426,6 +425,10 @@ def orcid_logged_in(_, token):
         token["orcid"],
         display_name=token["name"],
         verified=True,
+        # TODO: For now, this does not create a new user account if missing, but can be used
+        # to connect an existing user account with an ORCID identity (which can then be used
+        # for login).
+        create_account=False,
     )
 
     # Return false to prevent Flask-dance from trying to store the token elsewhere

--- a/webapp/src/components/EditAccountSettingsModal.vue
+++ b/webapp/src/components/EditAccountSettingsModal.vue
@@ -72,17 +72,17 @@
                 user.identities.find((identity) => identity.identity_type === 'orcid').name
               "
             >
-              <font-awesome-icon :icon="['fab', 'github']" />
+              <font-awesome-icon class="orcid-icon" :icon="['fab', 'orcid']" />
               {{ user.identities.find((identity) => identity.identity_type === "orcid").name }}
             </a>
             <a
               v-else
               type="button"
-              class="disabled dropdown-item btn login btn-link btn-default"
-              aria-label="Login via ORCID"
+              class="dropdown-item btn login btn-link btn-default"
+              aria-label="Connect ORCID account"
               :href="this.apiUrl + '/login/orcid'"
               ><font-awesome-icon class="orcid-icon" :icon="['fab', 'orcid']" /> Connect your
-              ORCiD</a
+              ORCID</a
             >
           </div>
         </div>

--- a/webapp/src/components/LoginDetails.vue
+++ b/webapp/src/components/LoginDetails.vue
@@ -69,7 +69,7 @@
           >
           <a
             type="button"
-            class="disabled dropdown-item btn login btn-link btn-default"
+            class="dropdown-item btn login btn-link btn-default"
             aria-label="Login via ORCID"
             :href="this.apiUrl + '/login/orcid'"
             ><font-awesome-icon class="orcid-icon" :icon="['fab', 'orcid']" /> Login via ORCID</a


### PR DESCRIPTION
Begins to address #645.

ORCID should now be enabled by default as a login source, when configured via the appropriate environment variables.

Eventually the UI should adapt to not show it as an option when not configured on the server.

For now, the user must still register an account via GitHub, but they can then connect their ORCID and use it for future logins.

Once #674 and #687 are merged, admins will be able to allow users to request an account via ORCID alone.