### PR TITLE
Only fix PRs with pre-commit CI when asked

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ default_language_version:
 ci:
   skip: [generate-schemas]
   autoupdate_schedule: "monthly"
+  autofix_prs: false
 
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks


### PR DESCRIPTION
This PR tweaks the pre-commit CI settings so that they only trigger when you ask in a comment "pre-commit.ci autofix". This should reduce the problems of mergeability checks on draft PRs, and will prevent the constant need for rebasing...