### PR TITLE
Added a way to refresh API Key from Account Settings UI

### DIFF
--- a/webapp/src/components/EditAccountSettingsModal.vue
+++ b/webapp/src/components/EditAccountSettingsModal.vue
@@ -90,7 +90,13 @@
           <div class="form-group col-md-12">
             <label for="api-key" class="col-form-label">API Key:</label>
             <div v-if="apiKeyDisplayed" class="input-group">
-              <input type="text" class="form-control" style='text-overflow: ellipsis' :value="apiKey" readonly />
+              <input
+                type="text"
+                class="form-control"
+                style="text-overflow: ellipsis"
+                :value="apiKey"
+                readonly
+              />
               <div class="input-group-append">
                 <button class="btn btn-outline-secondary" type="button" @click="copyToClipboard">
                   <font-awesome-icon icon="copy" />
@@ -98,7 +104,9 @@
               </div>
             </div>
             <div>
-                <button class="btn btn-default mt-2" @click="requestAPIKey">Regenerate API Key</button>
+              <button class="btn btn-default mt-2" @click="requestAPIKey">
+                Regenerate API Key
+              </button>
             </div>
           </div>
         </div>

--- a/webapp/src/components/EditAccountSettingsModal.vue
+++ b/webapp/src/components/EditAccountSettingsModal.vue
@@ -2,7 +2,7 @@
   <form @submit.prevent="submitForm" class="modal-enclosure">
     <Modal
       :modelValue="modelValue"
-      @update:modelValue="$emit('update:modelValue', $event)"
+      @update:modelValue="resetForm"
       :disableSubmit="
         Boolean(displayNameValidationMessage) || Boolean(contactEmailValidationMessage)
       "
@@ -86,6 +86,20 @@
             >
           </div>
         </div>
+        <div class="form-row">
+          <div class="form-group col-md-6">
+            <label for="account-name" class="col-form-label">API Key:</label>
+            <div v-if="apiKeyDisplayed" class="input-group">
+              <input type="text" class="form-control" :value="apiKey" readonly />
+              <div class="input-group-append">
+                <button class="btn btn-outline-secondary" type="button" @click="copyToClipboard">
+                  <font-awesome-icon icon="copy" />
+                </button>
+              </div>
+            </div>
+            <button class="btn btn-default mt-2" @click="requestAPIKey">Request New API Key</button>
+          </div>
+        </div>
       </template>
     </Modal>
   </form>
@@ -94,7 +108,7 @@
 <script>
 import { API_URL } from "@/resources.js";
 import Modal from "@/components/Modal.vue";
-import { getUserInfo, saveUser } from "@/server_fetch_utils.js";
+import { getUserInfo, saveUser, requestNewAPIKey } from "@/server_fetch_utils.js";
 export default {
   name: "EditAccountSettingsModal",
   data() {
@@ -105,6 +119,8 @@ export default {
         identities: [],
       },
       apiUrl: API_URL,
+      apiKeyDisplayed: false,
+      apiKey: null,
     };
   },
   props: {
@@ -140,6 +156,29 @@ export default {
       if (user != null) {
         this.user = user;
       }
+    },
+    async requestAPIKey(event) {
+      event.preventDefault();
+      if (
+        window.confirm(
+          "Requesting a new API key will remove your old one. Are you sure you want to proceed?",
+        )
+      ) {
+        const newKey = await requestNewAPIKey();
+        this.apiKey = newKey;
+        this.apiKeyDisplayed = true;
+        window.alert(
+          `A new API key has been generated. Please note that when you close the "Account Settings" window, the key will not be displayed again. `,
+        );
+      }
+    },
+    copyToClipboard() {
+      navigator.clipboard.writeText(this.apiKey);
+    },
+    resetForm() {
+      this.apiKeyDisplayed = false;
+      this.apiKey = null;
+      this.$emit("update:modelValue", false);
     },
   },
   mounted() {

--- a/webapp/src/components/EditAccountSettingsModal.vue
+++ b/webapp/src/components/EditAccountSettingsModal.vue
@@ -87,17 +87,19 @@
           </div>
         </div>
         <div class="form-row">
-          <div class="form-group col-md-6">
-            <label for="account-name" class="col-form-label">API Key:</label>
+          <div class="form-group col-md-12">
+            <label for="api-key" class="col-form-label">API Key:</label>
             <div v-if="apiKeyDisplayed" class="input-group">
-              <input type="text" class="form-control" :value="apiKey" readonly />
+              <input type="text" class="form-control" style='text-overflow: ellipsis' :value="apiKey" readonly />
               <div class="input-group-append">
                 <button class="btn btn-outline-secondary" type="button" @click="copyToClipboard">
                   <font-awesome-icon icon="copy" />
                 </button>
               </div>
             </div>
-            <button class="btn btn-default mt-2" @click="requestAPIKey">Request New API Key</button>
+            <div>
+                <button class="btn btn-default mt-2" @click="requestAPIKey">Regenerate API Key</button>
+            </div>
           </div>
         </div>
       </template>

--- a/webapp/src/main.js
+++ b/webapp/src/main.js
@@ -40,6 +40,7 @@ import {
   faSearch,
   faSpinner,
   faEllipsisH,
+  faCopy,
 } from "@fortawesome/free-solid-svg-icons";
 import { faPlusSquare } from "@fortawesome/free-regular-svg-icons";
 import { faGithub, faOrcid } from "@fortawesome/free-brands-svg-icons";
@@ -79,6 +80,7 @@ library.add(
   faPlusSquare,
   faSpinner,
   faEllipsisH,
+  faCopy,
 );
 
 // Import TinyMCE

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -616,6 +616,21 @@ export async function getItemGraph({ item_id = null, collection_id = null } = {}
     .catch((error) => `getItemGraph unsuccessful. Error: ${error}`);
 }
 
+export async function requestNewAPIKey() {
+  try {
+    const response_json = await fetch_get(`${API_URL}/get-api-key/`);
+
+    if (response_json.key) {
+      console.log("New API key requested successfully!");
+      return response_json.key;
+    } else {
+      throw new Error(response_json.message);
+    }
+  } catch (error) {
+    throw new Error(`Failed to request new API key: ${error.message}`);
+  }
+}
+
 // export async function addRemoteFilesToSample(file_entries, item_id) {
 //  console.log('loadSelectedRemoteFiles')
 //  return fetch_post(`${API_URL}/add-remote-files-to-sample/`, {


### PR DESCRIPTION
Closes #695 

I've added a button in "Account Settings" to refresh the user's API key.
There's a warning message indicating that the old key will be deleted.
The key is displayed in the "Account Settings" Modal and disappears once the user closes the Modal.

