### PR TITLE
Update deployment instructions wrt. new datalab-ansible-terraform repo

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,8 +145,6 @@ jobs:
 
       - name: Start Docker images
         run: |
-          # Create a named docker network that all containers attach to
-          docker network create nginx
           # Add default API URL argument to Vue prod build
           echo "VUE_APP_API_URL=http://localhost:5001" >> .env
           # Launch production container profiles and wait for them to come up

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   app:
     profiles: ["prod"]
@@ -16,8 +14,6 @@ services:
       - VUE_APP_EDITABLE_INVENTORY
     ports:
       - "8081:8081"
-    networks:
-      - nginx
 
   app_dev:
     profiles: ["dev"]
@@ -30,8 +26,6 @@ services:
       - ./webapp:/app
     ports:
       - "8081:8081"
-    networks:
-      - nginx
 
   api:
     profiles: ["prod"]
@@ -48,7 +42,6 @@ services:
     ports:
       - "5001:5001"
     networks:
-      - nginx
       - backend
     environment:
       - PYDATALAB_MONGO_URI=mongodb://database:27017/datalabvue
@@ -67,7 +60,6 @@ services:
     ports:
       - "5001:5001"
     networks:
-      - nginx
       - backend
     environment:
       - PYDATALAB_TESTING=true
@@ -85,8 +77,5 @@ services:
       - "27017:27017"
 
 networks:
-  nginx:
-    external: true
-
   backend:
     driver: bridge

--- a/pydatalab/docs/deployment.md
+++ b/pydatalab/docs/deployment.md
@@ -17,6 +17,26 @@ These instructions assume that Docker is installed (a recent version that includ
 See the [Docker website](https://docs.docker.com/compose/install/) for instructions for your system.
 Note that pulling and building the images can require significant disk space (~5 GB for a full setup), especially when multiple versions of images have been built (you can use `docker system df` to see how much spaace is being used).
 
+## Automated provisioning and deployments
+
+There are many more advanced tools for provisioning containers and services.
+[Terraform](https://www.terraform.io/) or its open source fork
+[OpenTofu](https://opentofu.org/) can be used to define and provision cloud resources with
+code.
+[Ansible](https://www.ansible.com/) can be used to automate the deployment of
+containers and configuration to such resources.
+
+Configurations/rules/playbooks for these systems have been written for *datalab*
+and are used in production by many deployments.
+They are available with their own instructions at
+[datalab-org/datalab-ansible-terraform](https://github.com/datalab-org/datalab-ansible-terraform)
+on GitHub.
+
+These automated configurations require a bit more work and understanding, but
+can greatly accelerate the deployment process and make it much more
+reproducible.
+
+
 ## Deployment with Docker and Docker Compose
 
 Dockerfiles for the web app, server and database can be found in the `.docker` directory.
@@ -129,7 +149,6 @@ The process may look something like the following:
     ports:
       - "5001:5001"
     networks:
-      - nginx  # connect container to external network named 'nginx' that could communicate with the outside world
       - backend
     environment:
       - PYDATALAB_MONGO_URI=mongodb://database:27017/datalab
@@ -183,21 +202,6 @@ docker compose --file docker-compose.prod.yml --profile prod build
 # If nothing went wrong, launch the new containers (these will replace any running containers)
 docker compose --file docker-compose.prod.yml --profile prod up
 ```
-
-
-### Advanced provisioning
-
-There are many more advanced tools for provisioning containers and services.
-[Terraform](https://www.terraform.io/) or its open source fork
-[OpenTofu](https://opentofu.org/) can be used to define and provision cloud resources with
-code.
-[Ansible](https://www.ansible.com/) can be used to automate the deployment of
-containers and configuration to such resources.
-
-Configurations/rules/playbooks for these systems have been written for *datalab*
-and are used in production by many deployments; they are not yet general enough
-to be open sourced, but if you are interested please contact the *datalab*
-developers (via email or GitHub issues).
 
 
 ## General Server administration


### PR DESCRIPTION
This PR updates the deployment instructions now that the datalab-ansible-terraform repo is live.

It also removes the need to have an external docker network called nginx, which was a vestige of our initial deployment process.