### PR TITLE
Populating dynamic block-level documentation as UI tooltips

### DIFF
--- a/pydatalab/pydatalab/apps/chat/blocks.py
+++ b/pydatalab/pydatalab/apps/chat/blocks.py
@@ -1,6 +1,5 @@
 import json
 import os
-from typing import Sequence
 
 from langchain_anthropic import ChatAnthropic
 from langchain_core.language_models.chat_models import BaseChatModel
@@ -35,7 +34,7 @@ class ChatBlock(DataBlock):
     blocktype = "chat"
     description = "Virtual LLM assistant block allows you to converse with your data."
     name = "💬 Chat with Whinchat"
-    accepted_file_extensions: Sequence[str] = []
+    accepted_file_extensions = None
     chat_client: BaseChatModel | None = None
 
     __supports_collections = True

--- a/pydatalab/pydatalab/apps/eis/__init__.py
+++ b/pydatalab/pydatalab/apps/eis/__init__.py
@@ -23,7 +23,7 @@ def parse_ivium_eis_txt(filename: Path):
 
 
 class EISBlock(DataBlock):
-    accepted_file_extensions = [".txt"]
+    accepted_file_extensions = (".txt",)
     blocktype = "eis"
     name = "EIS"
     description = "This block can plot electrochemical impedance spectroscopy (EIS) data from Ivium .txt files"

--- a/pydatalab/pydatalab/apps/nmr/blocks.py
+++ b/pydatalab/pydatalab/apps/nmr/blocks.py
@@ -17,7 +17,7 @@ class NMRBlock(DataBlock):
     name = "NMR"
     description = "A simple NMR block for visualizing 1D NMR data from Bruker projects."
 
-    accepted_file_extensions = ".zip"
+    accepted_file_extensions = (".zip",)
     defaults = {"process number": 1}
     _supports_collections = False
 
@@ -27,10 +27,12 @@ class NMRBlock(DataBlock):
 
     def read_bruker_nmr_data(self):
         if "file_id" not in self.data:
-            LOGGER.warning("NMRPlot.read_bruker_nmr_data(): No file set in the DataBlock")
+            LOGGER.warning(
+                "NMRPlot.read_bruker_nmr_data(): No file set in the DataBlock")
             return
 
-        zip_file_info = get_file_info_by_id(self.data["file_id"], update_if_live=True)
+        zip_file_info = get_file_info_by_id(
+            self.data["file_id"], update_if_live=True)
         filename = zip_file_info["name"]
 
         name, ext = os.path.splitext(filename)
@@ -47,7 +49,8 @@ class NMRBlock(DataBlock):
             zip_ref.extractall(directory_location)
 
         extracted_directory_name = os.path.join(directory_location, name)
-        available_processes = os.listdir(os.path.join(extracted_directory_name, "pdata"))
+        available_processes = os.listdir(
+            os.path.join(extracted_directory_name, "pdata"))
 
         if self.data.get("selected_process") not in available_processes:
             self.data["selected_process"] = available_processes[0]
@@ -59,7 +62,8 @@ class NMRBlock(DataBlock):
                 verbose=False,
             )
         except Exception as error:
-            LOGGER.critical(f"Unable to parse {name} as Bruker project. {error}")
+            LOGGER.critical(
+                f"Unable to parse {name} as Bruker project. {error}")
             return
 
         serialized_df = df.to_dict() if (df is not None) else None
@@ -85,7 +89,8 @@ class NMRBlock(DataBlock):
         self.data["topspin_title"] = topspin_title
 
     def generate_nmr_plot(self):
-        self.read_bruker_nmr_data()  # currently calls every time plotting happens, but it should only happen if the file was updated
+        # currently calls every time plotting happens, but it should only happen if the file was updated
+        self.read_bruker_nmr_data()
         if "processed_data" not in self.data or not self.data["processed_data"]:
             self.data["bokeh_plot_data"] = None
             return
@@ -104,7 +109,8 @@ class NMRBlock(DataBlock):
             plot_line=True,
             point_size=3,
         )
-        bokeh_layout.children[0].x_range.flipped = True  # flip x axis, per NMR convention
+        # flip x axis, per NMR convention
+        bokeh_layout.children[0].x_range.flipped = True
 
         self.data["bokeh_plot_data"] = bokeh.embed.json_item(
             bokeh_layout, theme=DATALAB_BOKEH_THEME

--- a/pydatalab/pydatalab/apps/nmr/blocks.py
+++ b/pydatalab/pydatalab/apps/nmr/blocks.py
@@ -27,12 +27,10 @@ class NMRBlock(DataBlock):
 
     def read_bruker_nmr_data(self):
         if "file_id" not in self.data:
-            LOGGER.warning(
-                "NMRPlot.read_bruker_nmr_data(): No file set in the DataBlock")
+            LOGGER.warning("NMRPlot.read_bruker_nmr_data(): No file set in the DataBlock")
             return
 
-        zip_file_info = get_file_info_by_id(
-            self.data["file_id"], update_if_live=True)
+        zip_file_info = get_file_info_by_id(self.data["file_id"], update_if_live=True)
         filename = zip_file_info["name"]
 
         name, ext = os.path.splitext(filename)
@@ -49,8 +47,7 @@ class NMRBlock(DataBlock):
             zip_ref.extractall(directory_location)
 
         extracted_directory_name = os.path.join(directory_location, name)
-        available_processes = os.listdir(
-            os.path.join(extracted_directory_name, "pdata"))
+        available_processes = os.listdir(os.path.join(extracted_directory_name, "pdata"))
 
         if self.data.get("selected_process") not in available_processes:
             self.data["selected_process"] = available_processes[0]
@@ -62,8 +59,7 @@ class NMRBlock(DataBlock):
                 verbose=False,
             )
         except Exception as error:
-            LOGGER.critical(
-                f"Unable to parse {name} as Bruker project. {error}")
+            LOGGER.critical(f"Unable to parse {name} as Bruker project. {error}")
             return
 
         serialized_df = df.to_dict() if (df is not None) else None

--- a/pydatalab/pydatalab/apps/tga/blocks.py
+++ b/pydatalab/pydatalab/apps/tga/blocks.py
@@ -17,7 +17,7 @@ class MassSpecBlock(DataBlock):
     blocktype = "ms"
     name = "Mass spectrometry"
     description = "Read and visualize mass spectrometry data as a grid plot per channel"
-    accepted_file_extensions = (".asc",)
+    accepted_file_extensions = (".asc", ".txt")
 
     @property
     def plot_functions(self):

--- a/pydatalab/pydatalab/blocks/base.py
+++ b/pydatalab/pydatalab/blocks/base.py
@@ -45,7 +45,7 @@ class DataBlock:
     """A longer description outlining the purpose and capability
     of the block."""
 
-    accepted_file_extensions: Sequence[str]
+    accepted_file_extensions: tuple[str, ...] | None
     """A list of file extensions that the block will attempt to read."""
 
     defaults: Dict[str, Any] = {}

--- a/webapp/src/components/StyledAnchor.vue
+++ b/webapp/src/components/StyledAnchor.vue
@@ -9,7 +9,6 @@
     >{{ blockInfo.name }}</a
   >
   <div ref="tooltipContent" id="tooltip" role="tooltip">
-    <p class="tooltipTitle">{{ blockInfo.name }}</p>
     <p>{{ blockInfo.description }}</p>
     <p v-if="blockInfo.accepted_file_extensions.length > 0">
       Accepted file extensions:

--- a/webapp/src/components/StyledAnchor.vue
+++ b/webapp/src/components/StyledAnchor.vue
@@ -1,0 +1,92 @@
+<template>
+  <a
+    ref="anchor"
+    class="dropdown-item"
+    @mouseenter="delayedShowTooltip"
+    @mouseleave="hideTooltip"
+    @focus="delayedShowTooltip"
+    @blur="hideTooltip"
+    >{{ blockInfo.name }}</a
+  >
+  <div ref="tooltipContent" id="tooltip" role="tooltip">
+    <p class="tooltipTitle">{{ blockInfo.name }}</p>
+    <p>{{ blockInfo.description }}</p>
+  </div>
+</template>
+
+<script>
+import { createPopper } from "@popperjs/core";
+
+export default {
+  name: "StyledAnchor",
+  props: {
+    blockInfo: {
+      type: Object,
+    },
+  },
+  data() {
+    return {
+      tooltipDisplay: false,
+      tooltipTimeout: null,
+      popperInstance: null,
+    };
+  },
+  methods: {
+    delayedShowTooltip() {
+      this.tooltipTimeout = setTimeout(() => {
+        if (this.blockInfo) {
+          this.$refs.tooltipContent.setAttribute("data-show", "");
+          this.popperInstance.update();
+        }
+      }, 1000);
+    },
+
+    hideTooltip() {
+      clearTimeout(this.tooltipTimeout);
+      this.$refs.tooltipContent.removeAttribute("data-show");
+    },
+  },
+  mounted() {
+    const anchor = this.$refs.anchor;
+    const tooltip = this.$refs.tooltipContent;
+
+    this.popperInstance = createPopper(anchor, tooltip, {
+      placement: "bottom-start",
+      strategy: "fixed",
+      modifiers: [
+        {
+          name: "offset",
+          options: {
+            offset: [0, 4],
+          },
+        },
+      ],
+    });
+  },
+};
+</script>
+
+<style scoped>
+input {
+  border: 1px solid grey;
+}
+
+#tooltip {
+  z-index: 9999;
+  border: 1px solid grey;
+  width: auto;
+  background: #333;
+  color: white;
+  font-weight: bold;
+  padding: 1em;
+  border-radius: 4px;
+}
+
+#tooltip {
+  display: none;
+}
+
+#tooltip[data-show] {
+  display: block;
+}
+</style>

--- a/webapp/src/components/StyledAnchor.vue
+++ b/webapp/src/components/StyledAnchor.vue
@@ -11,6 +11,12 @@
   <div ref="tooltipContent" id="tooltip" role="tooltip">
     <p class="tooltipTitle">{{ blockInfo.name }}</p>
     <p>{{ blockInfo.description }}</p>
+    <p v-if="blockInfo.accepted_file_extensions.length > 0">
+      Accepted file extensions:
+      <span v-for="(extension, index) in blockInfo.accepted_file_extensions" :key="index">
+        {{ extension }}{{ index < blockInfo.accepted_file_extensions.length - 1 ? ", " : "" }}
+      </span>
+    </p>
   </div>
 </template>
 

--- a/webapp/src/components/StyledBlockHelp.vue
+++ b/webapp/src/components/StyledBlockHelp.vue
@@ -10,7 +10,12 @@
   >
   <div ref="tooltipContent" id="tooltip" role="tooltip">
     <p>{{ blockInfo.description }}</p>
-    <p class="accepted-file" v-if="blockInfo.accepted_file_extensions.length > 0">
+    <p
+      class="accepted-file"
+      v-if="
+        blockInfo.accepted_file_extensions != null && blockInfo.accepted_file_extensions.length > 0
+      "
+    >
       Accepted file extensions:
       <span v-for="(extension, index) in blockInfo.accepted_file_extensions" :key="index">
         {{ extension }}{{ index < blockInfo.accepted_file_extensions.length - 1 ? ", " : "" }}

--- a/webapp/src/components/StyledBlockHelp.vue
+++ b/webapp/src/components/StyledBlockHelp.vue
@@ -43,7 +43,7 @@ export default {
           this.$refs.tooltipContent.setAttribute("data-show", "");
           this.popperInstance.update();
         }
-      }, 1000);
+      }, 500);
     },
 
     hideTooltip() {
@@ -85,6 +85,10 @@ input {
   font-weight: bold;
   padding: 1em;
   border-radius: 4px;
+}
+
+#tooltip p {
+  margin: 0;
 }
 
 #tooltip {

--- a/webapp/src/components/StyledBlockHelp.vue
+++ b/webapp/src/components/StyledBlockHelp.vue
@@ -23,7 +23,7 @@
 import { createPopper } from "@popperjs/core";
 
 export default {
-  name: "StyledAnchor",
+  name: "StyledBlockHelp",
   props: {
     blockInfo: {
       type: Object,

--- a/webapp/src/components/StyledBlockHelp.vue
+++ b/webapp/src/components/StyledBlockHelp.vue
@@ -10,7 +10,7 @@
   >
   <div ref="tooltipContent" id="tooltip" role="tooltip">
     <p>{{ blockInfo.description }}</p>
-    <p v-if="blockInfo.accepted_file_extensions.length > 0">
+    <p class="accepted-file" v-if="blockInfo.accepted_file_extensions.length > 0">
       Accepted file extensions:
       <span v-for="(extension, index) in blockInfo.accepted_file_extensions" :key="index">
         {{ extension }}{{ index < blockInfo.accepted_file_extensions.length - 1 ? ", " : "" }}
@@ -89,6 +89,10 @@ input {
 
 #tooltip p {
   margin: 0;
+}
+
+.accepted-file {
+  padding-top: 0.5em;
 }
 
 #tooltip {

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -643,3 +643,15 @@ export async function requestNewAPIKey() {
     throw new Error(`Failed to request new API key: ${error.message}`);
   }
 }
+
+export function getBlocksInfos() {
+  return fetch_get(`${API_URL}/info/blocks`)
+    .then(function (response_json) {
+      return response_json.data;
+    })
+    .catch((error) => {
+      console.error("Error when fetching blocks info");
+      console.error(error);
+      throw error;
+    });
+}

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -647,6 +647,7 @@ export async function requestNewAPIKey() {
 export function getBlocksInfos() {
   return fetch_get(`${API_URL}/info/blocks`)
     .then(function (response_json) {
+      store.commit("setBlocksInfos", response_json.data);
       return response_json.data;
     })
     .catch((error) => {

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -27,7 +27,7 @@ export default createStore({
     remoteDirectoryTreeIsLoading: false,
     fileSelectModalIsOpen: false,
     currentUserDisplayName: null,
-    blocksInfos: null,
+    blocksInfos: {},
   },
   mutations: {
     setSampleList(state, sampleSummaries) {
@@ -265,7 +265,10 @@ export default createStore({
       state.itemGraphData = payload;
     },
     setBlocksInfos(state, blocksInfos) {
-      state.blocksInfos = blocksInfos;
+      state.blocksInfos = {};
+      blocksInfos.forEach((info) => {
+        state.blocksInfos[info.id] = info;
+      });
     },
   },
   getters: {

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -265,7 +265,6 @@ export default createStore({
       state.itemGraphData = payload;
     },
     setBlocksInfos(state, blocksInfos) {
-      state.blocksInfos = {};
       blocksInfos.forEach((info) => {
         state.blocksInfos[info.id] = info;
       });

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -27,6 +27,7 @@ export default createStore({
     remoteDirectoryTreeIsLoading: false,
     fileSelectModalIsOpen: false,
     currentUserDisplayName: null,
+    blocksInfos: null,
   },
   mutations: {
     setSampleList(state, sampleSummaries) {
@@ -262,6 +263,9 @@ export default createStore({
     },
     setItemGraph(state, payload) {
       state.itemGraphData = payload;
+    },
+    setBlocksInfos(state, blocksInfos) {
+      state.blocksInfos = blocksInfos;
     },
   },
   getters: {

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -205,12 +205,6 @@ export default {
         this.lastModified = formatDistanceToNow(save_date, { addSuffix: true });
       }
     },
-    async getBlocksInfo() {
-      if (!this.blocksInfos) {
-        let data = await getBlocksInfos();
-        this.$store.commit("setBlocksInfos", data);
-      }
-    },
   },
   computed: {
     itemType() {
@@ -252,7 +246,7 @@ export default {
     },
   },
   created() {
-    this.getBlocksInfo();
+    getBlocksInfos();
     this.getSampleData();
     this.interval = setInterval(() => this.setLastModified(), 30000);
   },
@@ -284,7 +278,6 @@ export default {
 
     // setup the uppy instsance
     setupUppy(this.item_id, "#uppy-trigger", this.stored_files);
-    this.getBlocksInfo();
   },
   beforeUnmount() {
     document.removeEventListener("keydown", this._keyListener);

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -28,14 +28,11 @@
           aria-labelledby="navbarDropdown"
           v-show="isMenuDropdownVisible"
         >
-          <a
-            v-for="(blockType, id) in blockTypes"
-            :key="id"
-            class="dropdown-item"
-            @click="newBlock($event, id)"
-          >
-            {{ blockType.name }}
-          </a>
+          <template v-for="blockInfo in blocksInfos" :key="blockInfo.id">
+            <span v-if="blockInfo.id !== 'notsupported'" @click="newBlock($event, blockInfo.id)">
+              <StyledAnchor :blockInfo="blockInfo.attributes" />
+            </span>
+          </template>
         </div>
       </div>
       <a class="nav-item nav-link" :href="this.itemApiUrl" target="_blank">
@@ -97,7 +94,13 @@ import SelectableFileTree from "@/components/SelectableFileTree";
 
 import FileList from "@/components/FileList";
 import FileSelectModal from "@/components/FileSelectModal";
-import { getItemData, addABlock, saveItem, updateBlockFromServer } from "@/server_fetch_utils";
+import {
+  getItemData,
+  addABlock,
+  saveItem,
+  updateBlockFromServer,
+  getBlocksInfos,
+} from "@/server_fetch_utils";
 import FormattedItemName from "@/components/FormattedItemName";
 
 import setupUppy from "@/file_upload.js";
@@ -108,6 +111,8 @@ import { blockTypes, itemTypes } from "@/resources.js";
 import NotImplementedBlock from "@/components/datablocks/NotImplementedBlock.vue";
 import { API_URL } from "@/resources.js";
 import { formatDistanceToNow } from "date-fns";
+
+import StyledAnchor from "@/components/StyledAnchor";
 
 export default {
   data() {
@@ -120,6 +125,7 @@ export default {
       isLoadingRemoteFiles: false,
       isLoadingNewBlock: false,
       lastModified: null,
+      blocksInfos: null,
     };
   },
   methods: {
@@ -200,6 +206,13 @@ export default {
         this.lastModified = formatDistanceToNow(save_date, { addSuffix: true });
       }
     },
+    async getBlocksInfo() {
+      let data = await getBlocksInfos();
+      this.blocksInfos = data;
+      console.log("$$$$$$$$$$$$$$$");
+      console.log(this.blocksInfos);
+      console.log("$$$$$$$$$$$$$$$");
+    },
   },
   computed: {
     itemType() {
@@ -247,6 +260,7 @@ export default {
     FileList,
     FileSelectModal,
     FormattedItemName,
+    StyledAnchor,
   },
   beforeMount() {
     this.blockTypes = blockTypes; // bind blockTypes as a NON-REACTIVE object to the this context so that it is accessible by the template.
@@ -268,6 +282,7 @@ export default {
 
     // setup the uppy instsance
     setupUppy(this.item_id, "#uppy-trigger", this.stored_files);
+    this.getBlocksInfo();
   },
   beforeUnmount() {
     document.removeEventListener("keydown", this._keyListener);

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -30,7 +30,7 @@
         >
           <template v-for="blockInfo in blocksInfos" :key="blockInfo.id">
             <span v-if="blockInfo.id !== 'notsupported'" @click="newBlock($event, blockInfo.id)">
-              <StyledAnchor :blockInfo="blockInfo.attributes" />
+              <StyledBlockHelp :blockInfo="blockInfo.attributes" />
             </span>
           </template>
         </div>
@@ -112,7 +112,7 @@ import NotImplementedBlock from "@/components/datablocks/NotImplementedBlock.vue
 import { API_URL } from "@/resources.js";
 import { formatDistanceToNow } from "date-fns";
 
-import StyledAnchor from "@/components/StyledAnchor";
+import StyledBlockHelp from "@/components/StyledBlockHelp";
 
 export default {
   data() {
@@ -262,7 +262,7 @@ export default {
     FileList,
     FileSelectModal,
     FormattedItemName,
-    StyledAnchor,
+    StyledBlockHelp,
   },
   beforeMount() {
     this.blockTypes = blockTypes; // bind blockTypes as a NON-REACTIVE object to the this context so that it is accessible by the template.

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -125,7 +125,6 @@ export default {
       isLoadingRemoteFiles: false,
       isLoadingNewBlock: false,
       lastModified: null,
-      blocksInfos: null,
     };
   },
   methods: {
@@ -207,8 +206,10 @@ export default {
       }
     },
     async getBlocksInfo() {
-      let data = await getBlocksInfos();
-      this.blocksInfos = data;
+      if (!this.blocksInfos) {
+        let data = await getBlocksInfos();
+        this.$store.commit("setBlocksInfos", data);
+      }
     },
   },
   computed: {
@@ -246,8 +247,12 @@ export default {
     stored_files() {
       return this.$store.state.files;
     },
+    blocksInfos() {
+      return this.$store.state.blocksInfos;
+    },
   },
   created() {
+    this.getBlocksInfo();
     this.getSampleData();
     this.interval = setInterval(() => this.setLastModified(), 30000);
   },

--- a/webapp/src/views/EditPage.vue
+++ b/webapp/src/views/EditPage.vue
@@ -209,9 +209,6 @@ export default {
     async getBlocksInfo() {
       let data = await getBlocksInfos();
       this.blocksInfos = data;
-      console.log("$$$$$$$$$$$$$$$");
-      console.log(this.blocksInfos);
-      console.log("$$$$$$$$$$$$$$$");
     },
   },
   computed: {


### PR DESCRIPTION
Related to #705 & #667 

Add information for each block with popper.js on hover in the “Add a block” dropdown inside the EditPage.
The names in the dropdown are slightly different, as we now use those fetched directly from the models and not those in @resource.js (can be change if needed).

The design of the popper.js window is customizable, so don't hesitate to give me feedback.

![Screenshot 2024-04-27 at 13 13 42](https://github.com/the-grey-group/datalab/assets/107116804/1bcf1bfe-d5dc-4316-bbec-3ba8484c8597)


