### PR TITLE
Consider account status during auth and refactor API around blueprints

### DIFF
--- a/pydatalab/pydatalab/login.py
+++ b/pydatalab/pydatalab/login.py
@@ -10,7 +10,7 @@ from bson import ObjectId
 from flask_login import LoginManager, UserMixin
 
 from pydatalab.models import Person
-from pydatalab.models.people import Identity, IdentityType
+from pydatalab.models.people import AccountStatus, Identity, IdentityType
 from pydatalab.models.utils import UserRole
 from pydatalab.mongo import flask_mongo
 
@@ -57,6 +57,11 @@ class LoginUser(UserMixin):
     def contact_email(self) -> Optional[str]:
         """Returns the top-level contact email for the user, if set."""
         return self.person.contact_email
+
+    @property
+    def account_status(self) -> AccountStatus:
+        """Returns the account status of the user."""
+        return self.person.account_status
 
     @property
     def identities(self) -> List[Identity]:

--- a/pydatalab/pydatalab/permissions.py
+++ b/pydatalab/pydatalab/permissions.py
@@ -1,6 +1,7 @@
 from functools import wraps
 from typing import Any, Dict
 
+from flask import request
 from flask_login import current_user
 
 from pydatalab.config import CONFIG
@@ -10,17 +11,39 @@ from pydatalab.models.people import AccountStatus
 from pydatalab.mongo import get_database
 
 
-def active_users_only(func):
-    """Decorator to ensure that only active user accounts can access a route."""
+def active_users_or_get_only(func):
+    """Decorator to ensure that only active user accounts can access a non-GET route."""
 
     @wraps(func)
     def wrapped_route(*args, **kwargs):
         if (
-            current_user.is_authenticated and current_user.account_status == AccountStatus.ACTIVE
-        ) or CONFIG.TESTING:
+            (current_user.is_authenticated and current_user.account_status == AccountStatus.ACTIVE)
+            or CONFIG.TESTING
+            or request.method in ("OPTIONS", "GET")
+        ):
             return func(*args, **kwargs)
 
         return {"error": "Unauthorized"}, 401
+
+    return wrapped_route
+
+
+def admin_only(func):
+    """Decorator to ensure that only admin user accounts can access a route."""
+
+    @wraps(func)
+    def wrapped_route(*args, **kwargs):
+        if (
+            current_user.is_authenticated
+            and current_user.role == UserRole.ADMIN
+            and current_user.account_status == AccountStatus.ACTIVE
+        ) or request.method in ("OPTIONS", "GET"):
+            return func(*args, **kwargs)
+
+        if not current_user.is_authenticated:
+            return {"error": "Unauthorized"}, 401
+
+        return {"error": "Insufficient privileges"}, 403
 
     return wrapped_route
 

--- a/pydatalab/pydatalab/routes/__init__.py
+++ b/pydatalab/pydatalab/routes/__init__.py
@@ -1,3 +1,3 @@
-from pydatalab.routes.v0_1 import BLUEPRINTS, ENDPOINTS, __api_version__, auth
+from pydatalab.routes.v0_1 import BLUEPRINTS, OAUTH, __api_version__
 
-__all__ = ("ENDPOINTS", "__api_version__", "auth", "BLUEPRINTS")
+__all__ = ("ENDPOINTS", "__api_version__", "OAUTH", "BLUEPRINTS")

--- a/pydatalab/pydatalab/routes/v0_1/__init__.py
+++ b/pydatalab/pydatalab/routes/v0_1/__init__.py
@@ -1,27 +1,30 @@
-from typing import Callable, Dict
+from flask import Blueprint
 
 from ._version import __api_version__
-from .admin import admin
-from .auth import ENDPOINTS as auth_endpoints
-from .blocks import ENDPOINTS as blocks_endpoints
-from .collections import collection
-from .files import ENDPOINTS as files_endpoints
-from .graphs import ENDPOINTS as graphs_endpoints
-from .healthcheck import ENDPOINTS as healthcheck_endpoints
-from .info import ENDPOINTS as info_endpoints
-from .items import items
-from .remotes import remote
-from .users import user
+from .admin import ADMIN
+from .auth import AUTH, OAUTH
+from .blocks import BLOCKS
+from .collections import COLLECTIONS
+from .files import FILES
+from .graphs import GRAPHS
+from .healthcheck import HEALTHCHECK
+from .info import INFO
+from .items import ITEMS
+from .remotes import REMOTES
+from .users import USERS
 
-ENDPOINTS: Dict[str, Callable] = {
-    **blocks_endpoints,
-    **files_endpoints,
-    **healthcheck_endpoints,
-    **auth_endpoints,
-    **graphs_endpoints,
-    **info_endpoints,
-}
+BLUEPRINTS: tuple[Blueprint, ...] = (
+    AUTH,
+    COLLECTIONS,
+    REMOTES,
+    USERS,
+    ADMIN,
+    ITEMS,
+    BLOCKS,
+    FILES,
+    HEALTHCHECK,
+    INFO,
+    GRAPHS,
+)
 
-BLUEPRINTS = [collection, remote, user, admin, items]
-
-__all__ = ("ENDPOINTS", "BLUEPRINTS", "__api_version__")
+__all__ = ("BLUEPRINTS", "OAUTH", "__api_version__")

--- a/pydatalab/pydatalab/routes/v0_1/__init__.py
+++ b/pydatalab/pydatalab/routes/v0_1/__init__.py
@@ -9,13 +9,12 @@ from .files import ENDPOINTS as files_endpoints
 from .graphs import ENDPOINTS as graphs_endpoints
 from .healthcheck import ENDPOINTS as healthcheck_endpoints
 from .info import ENDPOINTS as info_endpoints
-from .items import ENDPOINTS as items_endpoints
+from .items import items
 from .remotes import remote
 from .users import user
 
 ENDPOINTS: Dict[str, Callable] = {
     **blocks_endpoints,
-    **items_endpoints,
     **files_endpoints,
     **healthcheck_endpoints,
     **auth_endpoints,
@@ -23,6 +22,6 @@ ENDPOINTS: Dict[str, Callable] = {
     **info_endpoints,
 }
 
-BLUEPRINTS = [collection, remote, user, admin]
+BLUEPRINTS = [collection, remote, user, admin, items]
 
 __all__ = ("ENDPOINTS", "BLUEPRINTS", "__api_version__")

--- a/pydatalab/pydatalab/routes/v0_1/blocks.py
+++ b/pydatalab/pydatalab/routes/v0_1/blocks.py
@@ -5,17 +5,17 @@ from pydatalab.blocks import BLOCK_TYPES
 from pydatalab.blocks.base import DataBlock
 from pydatalab.logger import LOGGER
 from pydatalab.mongo import flask_mongo
-from pydatalab.permissions import active_users_only, get_default_permissions
+from pydatalab.permissions import active_users_or_get_only, get_default_permissions
 
-blocks = Blueprint("blocks", __name__)
+BLOCKS = Blueprint("blocks", __name__)
 
 
-@blocks.before_request
-@active_users_only
+@BLOCKS.before_request
+@active_users_or_get_only
 def _(): ...
 
 
-@blocks.route("/add-data-block/", methods=["POST"])
+@BLOCKS.route("/add-data-block/", methods=["POST"])
 def add_data_block():
     """Call with AJAX to add a block to the sample"""
 
@@ -75,7 +75,7 @@ def add_data_block():
     )
 
 
-@blocks.route("/add-collection-data-block/", methods=["POST"])
+@BLOCKS.route("/add-collection-data-block/", methods=["POST"])
 def add_collection_data_block():
     """Call with AJAX to add a block to the collection."""
 
@@ -175,7 +175,7 @@ def _save_block_to_db(block: DataBlock) -> bool:
         return True
 
 
-@blocks.route("/update-block/", methods=["POST"])
+@BLOCKS.route("/update-block/", methods=["POST"])
 def update_block():
     """Take in json block data from site, process, and spit
     out updated data. May be used, for example, when the user
@@ -202,7 +202,7 @@ def update_block():
     )
 
 
-@blocks.route("/delete-block/", methods=["POST"])
+@BLOCKS.route("/delete-block/", methods=["POST"])
 def delete_block():
     """Completely delete a data block from the database. In the future,
     we may consider preserving data by moving it to a different array,
@@ -238,7 +238,7 @@ def delete_block():
     )  # could try to switch to http 204 is "No Content" success with no json
 
 
-@blocks.route("/delete-collection-block/", methods=["POST"])
+@BLOCKS.route("/delete-collection-block/", methods=["POST"])
 def delete_collection_block():
     """Completely delete a data block from the database that is currently
     attached to a collection.

--- a/pydatalab/pydatalab/routes/v0_1/graphs.py
+++ b/pydatalab/pydatalab/routes/v0_1/graphs.py
@@ -1,11 +1,15 @@
-from typing import Callable, Dict, Optional, Set
+from typing import Optional, Set
 
-from flask import jsonify, request
+from flask import Blueprint, jsonify, request
 
 from pydatalab.mongo import flask_mongo
 from pydatalab.permissions import get_default_permissions
 
+GRAPHS = Blueprint("graphs", __name__)
 
+
+@GRAPHS.route("/item-graph", methods=["GET"])
+@GRAPHS.route("/item-graph/<item_id>", methods=["GET"])
 def get_graph_cy_format(item_id: Optional[str] = None, collection_id: Optional[str] = None):
     collection_id = request.args.get("collection_id", type=str)
 
@@ -155,12 +159,3 @@ def get_graph_cy_format(item_id: Optional[str] = None, collection_id: Optional[s
     ]
 
     return (jsonify(status="success", nodes=nodes, edges=edges), 200)
-
-
-get_graph_cy_format.methods = ("GET",)  # type: ignore
-
-
-ENDPOINTS: Dict[str, Callable] = {
-    "/item-graph/<item_id>": get_graph_cy_format,
-    "/item-graph": get_graph_cy_format,
-}

--- a/pydatalab/pydatalab/routes/v0_1/healthcheck.py
+++ b/pydatalab/pydatalab/routes/v0_1/healthcheck.py
@@ -1,8 +1,9 @@
-from typing import Callable, Dict
+from flask import Blueprint, jsonify
 
-from flask import jsonify
+HEALTHCHECK = Blueprint("healthcheck", __name__)
 
 
+@HEALTHCHECK.route("/healthcheck/is_ready", methods=["GET"])
 def is_ready():
     from pydatalab.mongo import check_mongo_connection
 
@@ -16,15 +17,6 @@ def is_ready():
     return (jsonify(status="success", message="Server and database are ready"), 200)
 
 
+@HEALTHCHECK.route("/healthcheck/is_alive", methods=["GET"])
 def is_alive():
     return (jsonify(status="success", message="Server is alive"), 200)
-
-
-is_alive.methods = ("GET",)  # type: ignore
-is_ready.methods = ("GET",)  # type: ignore
-
-
-ENDPOINTS: Dict[str, Callable] = {
-    "/healthcheck/is_alive": is_alive,
-    "/healthcheck/is_ready": is_ready,
-}

--- a/pydatalab/pydatalab/routes/v0_1/info.py
+++ b/pydatalab/pydatalab/routes/v0_1/info.py
@@ -3,9 +3,9 @@
 import json
 from datetime import datetime
 from functools import lru_cache
-from typing import Callable, Dict, List, Optional, Union
+from typing import Dict, List, Optional, Union
 
-from flask import jsonify, request
+from flask import Blueprint, jsonify, request
 from pydantic import AnyUrl, BaseModel, Field, validator
 
 from pydatalab import __version__
@@ -14,6 +14,8 @@ from pydatalab.models import Person
 from pydatalab.mongo import flask_mongo
 
 from ._version import __api_version__
+
+INFO = Blueprint("info", __name__)
 
 
 class Attributes(BaseModel):
@@ -80,6 +82,7 @@ def _get_deployment_metadata_once() -> Dict:
     return metadata
 
 
+@INFO.route("/info", methods=["GET"])
 def get_info():
     metadata = _get_deployment_metadata_once()
 
@@ -97,6 +100,7 @@ def get_info():
     )
 
 
+@INFO.route("/info/stats", methods=["GET"])
 def get_stats():
     """Returns a dictionary of counts of each entry type in the deployment"""
 
@@ -110,6 +114,7 @@ def get_stats():
     )
 
 
+@INFO.route("/info/blocks", methods=["GET"])
 def list_block_types():
     """Returns a list of all blocks implemented in this server."""
     return jsonify(
@@ -134,10 +139,3 @@ def list_block_types():
             ).json()
         )
     )
-
-
-ENDPOINTS: Dict[str, Callable] = {
-    "/info": get_info,
-    "/info/stats": get_stats,
-    "/info/blocks": list_block_types,
-}

--- a/pydatalab/pydatalab/routes/v0_1/items.py
+++ b/pydatalab/pydatalab/routes/v0_1/items.py
@@ -16,15 +16,14 @@ from pydatalab.models.items import Item
 from pydatalab.models.relationships import RelationshipType
 from pydatalab.models.utils import generate_unique_refcode
 from pydatalab.mongo import flask_mongo
-from pydatalab.permissions import active_users_only, get_default_permissions
+from pydatalab.permissions import active_users_or_get_only, get_default_permissions
 
-items = Blueprint("items", __name__)
+ITEMS = Blueprint("items", __name__)
 
 
-@items.before_request
-@active_users_only
-def _():
-    """Collect decorators to apply to the Items blueprint."""
+@ITEMS.before_request
+@active_users_or_get_only
+def _(): ...
 
 
 def reserialize_blocks(display_order: List[str], blocks_obj: Dict[str, Dict]) -> Dict[str, Dict]:
@@ -82,7 +81,7 @@ def dereference_files(file_ids: List[Union[str, ObjectId]]) -> Dict[str, Dict]:
     return results
 
 
-@items.route("/equipment/", methods=["GET"])
+@ITEMS.route("/equipment/", methods=["GET"])
 def get_equipment_summary():
     _project = {
         "_id": 0,
@@ -110,7 +109,7 @@ def get_equipment_summary():
     return jsonify({"status": "success", "items": items})
 
 
-@items.route("/starting-materials/", methods=["GET"])
+@ITEMS.route("/starting-materials/", methods=["GET"])
 def get_starting_materials():
     items = [
         doc
@@ -278,12 +277,12 @@ def _check_collections(sample_dict: dict) -> list[dict[str, str]]:
     return sample_dict.get("collections", []) or []
 
 
-@items.route("/samples/", methods=["GET"])
+@ITEMS.route("/samples/", methods=["GET"])
 def get_samples():
     return jsonify({"status": "success", "samples": list(get_samples_summary())})
 
 
-@items.route("/search-items/", methods=["GET"])
+@ITEMS.route("/search-items/", methods=["GET"])
 def search_items():
     """Perform free text search on items and return the top results.
     GET parameters:
@@ -549,7 +548,7 @@ def _create_sample(
     return data
 
 
-@items.route("/new-sample/", methods=["POST"])
+@ITEMS.route("/new-sample/", methods=["POST"])
 def create_sample():
     request_json = request.get_json()  # noqa: F821 pylint: disable=undefined-variable
     if "new_sample_data" in request_json:
@@ -564,7 +563,7 @@ def create_sample():
     return jsonify(response), http_code
 
 
-@items.route("/new-samples/", methods=["POST"])
+@ITEMS.route("/new-samples/", methods=["POST"])
 def create_samples():
     """attempt to create multiple samples at once.
     Because each may result in success or failure, 207 is returned along with a
@@ -604,7 +603,7 @@ def create_samples():
     )  # 207: multi-status
 
 
-@items.route("/delete-sample/", methods=["POST"])
+@ITEMS.route("/delete-sample/", methods=["POST"])
 def delete_sample():
     request_json = request.get_json()  # noqa: F821 pylint: disable=undefined-variable
     item_id = request_json["item_id"]
@@ -633,7 +632,7 @@ def delete_sample():
     )
 
 
-@items.route("/get-item-data/<item_id>", methods=["GET"])
+@ITEMS.route("/get-item-data/<item_id>", methods=["GET"])
 def get_item_data(item_id, load_blocks: bool = False):
     """Generates a JSON response for the item with the given `item_id`,
     additionally resolving relationships to files and other items.
@@ -766,7 +765,7 @@ def get_item_data(item_id, load_blocks: bool = False):
     )
 
 
-@items.route("/save-item/", methods=["POST"])
+@ITEMS.route("/save-item/", methods=["POST"])
 def save_item():
     request_json = request.get_json()  # noqa: F821 pylint: disable=undefined-variable
 
@@ -862,7 +861,7 @@ def save_item():
     return jsonify(status="success", last_modified=updated_data["last_modified"]), 200
 
 
-@items.route("/search-users/", methods=["GET"])
+@ITEMS.route("/search-users/", methods=["GET"])
 def search_users():
     """Perform free text search on users and return the top results.
     GET parameters:

--- a/pydatalab/pydatalab/routes/v0_1/remotes.py
+++ b/pydatalab/pydatalab/routes/v0_1/remotes.py
@@ -22,11 +22,11 @@ def _check_invalidate_cache(args: Dict[str, str]) -> Optional[bool]:
     return invalidate_cache
 
 
-remote = Blueprint("remotes", __name__)
+REMOTES = Blueprint("remotes", __name__)
 
 
-@remote.route("/list-remote-directories", methods=["GET"])
-@remote.route("/remotes", methods=["GET"])
+@REMOTES.route("/list-remote-directories", methods=["GET"])
+@REMOTES.route("/remotes", methods=["GET"])
 def list_remote_directories():
     """Returns the most recent directory structures from the server.
 
@@ -77,7 +77,7 @@ def list_remote_directories():
 list_remote_directories.methods = ("GET",)  # type: ignore
 
 
-@remote.route("/remotes/<path:remote_id>", methods=["GET"])
+@REMOTES.route("/remotes/<path:remote_id>", methods=["GET"])
 def get_remote_directory(remote_id: str):
     """Returns the directory structure from the server for the
     given configured remote name.

--- a/pydatalab/pydatalab/routes/v0_1/users.py
+++ b/pydatalab/pydatalab/routes/v0_1/users.py
@@ -6,10 +6,10 @@ from pydatalab.config import CONFIG
 from pydatalab.models.people import DisplayName, EmailStr
 from pydatalab.mongo import flask_mongo
 
-user = Blueprint("users", __name__)
+USERS = Blueprint("users", __name__)
 
 
-@user.route("/users/<user_id>", methods=["PATCH"])
+@USERS.route("/users/<user_id>", methods=["PATCH"])
 def save_user(user_id):
     request_json = request.get_json()
 

--- a/pydatalab/tests/server/conftest.py
+++ b/pydatalab/tests/server/conftest.py
@@ -11,6 +11,7 @@ from flask.testing import FlaskClient
 import pydatalab.mongo
 from pydatalab.main import create_app
 from pydatalab.models import Cell, Collection, Equipment, Sample, StartingMaterial
+from pydatalab.models.people import AccountStatus
 
 TEST_DATABASE_NAME = "__datalab-testing__"
 
@@ -128,44 +129,52 @@ def app(real_mongo_client, monkeypatch_session, app_config):
         mongo_cli.drop_database(TEST_DATABASE_NAME)
 
 
+def client_factory(app, api_key: str | None = None):
+    """Generates a test client for the API with the given API key."""
+
+    if api_key:
+
+        class AuthorizedTestClient(FlaskClient):
+            def open(self, *args, **kwargs):
+                kwargs.setdefault("headers", {"DATALAB_API_KEY": api_key})
+                return super().open(*args, **kwargs)
+
+        app.test_client_class = AuthorizedTestClient
+    else:
+        app.test_client_class = FlaskClient
+
+    with app.test_client() as cli:
+        return cli
+
+
 @pytest.fixture(scope="function")
 def admin_client(app, admin_api_key):
     """Returns a test client for the API with admin access."""
-
-    class AuthorizedTestClient(FlaskClient):
-        def open(self, *args, **kwargs):
-            kwargs.setdefault("headers", {"DATALAB_API_KEY": admin_api_key})
-            return super().open(*args, **kwargs)
-
-    app.test_client_class = AuthorizedTestClient
-
-    with app.test_client() as cli:
-        yield cli
+    yield client_factory(app, admin_api_key)
 
 
 @pytest.fixture(scope="function")
 def client(app, user_api_key):
     """Returns a test client for the API with normal user access."""
-
-    class AuthorizedTestClient(FlaskClient):
-        def open(self, *args, **kwargs):
-            kwargs.setdefault("headers", {"DATALAB_API_KEY": user_api_key})
-            return super().open(*args, **kwargs)
-
-    app.test_client_class = AuthorizedTestClient
-
-    with app.test_client() as cli:
-        yield cli
+    yield client_factory(app, user_api_key)
 
 
 @pytest.fixture(scope="function")
 def unauthenticated_client(app):
     """Returns an unauthenticated test client for the API."""
+    yield client_factory(app, None)
 
-    app.test_client_class = FlaskClient
 
-    with app.test_client() as cli:
-        yield cli
+@pytest.fixture(scope="function")
+def unverified_client(app, unverified_user_api_key):
+    """Returns a test client for the API with an unverified user's credentials."""
+    yield client_factory(app, unverified_user_api_key)
+
+
+@pytest.fixture(scope="function")
+def deactivated_client(app, deactivated_user_api_key):
+    """Returns a test client for the API with a deactivated user's credentials."""
+    yield client_factory(app, deactivated_user_api_key)
 
 
 def generate_api_key():
@@ -185,6 +194,16 @@ def user_api_key() -> str:
 
 
 @pytest.fixture(scope="session")
+def unverified_user_api_key() -> str:
+    return generate_api_key()
+
+
+@pytest.fixture(scope="session")
+def deactivated_user_api_key() -> str:
+    return generate_api_key()
+
+
+@pytest.fixture(scope="session")
 def user_id():
     yield ObjectId(24 * "1")
 
@@ -194,13 +213,24 @@ def admin_user_id():
     yield ObjectId(24 * "0")
 
 
-def insert_user(id, api_key, role, real_mongo_client):
+@pytest.fixture(scope="session")
+def unverified_user_id():
+    yield ObjectId(24 * "2")
+
+
+@pytest.fixture(scope="session")
+def deactivated_user_id():
+    yield ObjectId(24 * "3")
+
+
+def insert_user(id, api_key, role, real_mongo_client, status: AccountStatus = AccountStatus.ACTIVE):
     from hashlib import sha512
 
     demo_user = {
         "_id": id,
         "contact_email": "test@example.org",
         "display_name": "Test Admin",
+        "account_status": status,
     }
     real_mongo_client.get_database(TEST_DATABASE_NAME).users.insert_one(demo_user)
     hash = sha512(api_key.encode("utf-8")).hexdigest()
@@ -211,13 +241,34 @@ def insert_user(id, api_key, role, real_mongo_client):
 
 
 @pytest.fixture(scope="module", autouse=True)
-def insert_demo_user(app, user_id, user_api_key, real_mongo_client):
+def insert_demo_users(
+    app,
+    user_id,
+    user_api_key,
+    admin_user_id,
+    admin_api_key,
+    deactivated_user_id,
+    deactivated_user_api_key,
+    unverified_user_id,
+    unverified_user_api_key,
+    real_mongo_client,
+):
     insert_user(user_id, user_api_key, "user", real_mongo_client)
-
-
-@pytest.fixture(scope="module", autouse=True)
-def insert_demo_admin(app, admin_user_id, admin_api_key, real_mongo_client):
     insert_user(admin_user_id, admin_api_key, "admin", real_mongo_client)
+    insert_user(
+        deactivated_user_id,
+        deactivated_user_api_key,
+        "user",
+        real_mongo_client,
+        status=AccountStatus.DEACTIVATED,
+    )
+    insert_user(
+        unverified_user_id,
+        unverified_user_api_key,
+        "user",
+        real_mongo_client,
+        status=AccountStatus.UNVERIFIED,
+    )
 
 
 @pytest.fixture(scope="module", name="default_sample")

--- a/pydatalab/tests/server/test_permissions.py
+++ b/pydatalab/tests/server/test_permissions.py
@@ -5,23 +5,23 @@ def test_unverified_user_permissions(unverified_client):
     """Test permissions for an unverified user."""
     client = unverified_client
     response = client.get("/samples/")
-    assert response.status_code == 401
+    assert response.status_code == 200
 
     response = client.post("/new-sample/", json={"item_id": "test"})
     assert response.status_code == 401
 
     response = client.get("/starting-materials/")
-    assert response.status_code == 401
+    assert response.status_code == 200
 
 
 def test_deactivated_user_permissions(deactivated_client):
     """Test permissions for a deactivated user."""
     client = deactivated_client
     response = client.get("/samples/")
-    assert response.status_code == 401
+    assert response.status_code == 200
 
     response = client.post("/new-sample/", json={"item_id": "test"})
     assert response.status_code == 401
 
     response = client.get("/starting-materials/")
-    assert response.status_code == 401
+    assert response.status_code == 200

--- a/pydatalab/tests/server/test_permissions.py
+++ b/pydatalab/tests/server/test_permissions.py
@@ -1,0 +1,27 @@
+"""A set of non-exhaustive tests for user permissions in different scenarios."""
+
+
+def test_unverified_user_permissions(unverified_client):
+    """Test permissions for an unverified user."""
+    client = unverified_client
+    response = client.get("/samples/")
+    assert response.status_code == 401
+
+    response = client.post("/new-sample/", json={"item_id": "test"})
+    assert response.status_code == 401
+
+    response = client.get("/starting-materials/")
+    assert response.status_code == 401
+
+
+def test_deactivated_user_permissions(deactivated_client):
+    """Test permissions for a deactivated user."""
+    client = deactivated_client
+    response = client.get("/samples/")
+    assert response.status_code == 401
+
+    response = client.post("/new-sample/", json={"item_id": "test"})
+    assert response.status_code == 401
+
+    response = client.get("/starting-materials/")
+    assert response.status_code == 401


### PR DESCRIPTION
Closes #710 by refactoring all routes around blueprints and introducing some new decorators for permissions based on  `account_status`.