### PR TITLE
Allow txt files in MS block again

### DIFF
--- a/pydatalab/pydatalab/apps/tga/blocks.py
+++ b/pydatalab/pydatalab/apps/tga/blocks.py
@@ -17,7 +17,7 @@ class MassSpecBlock(DataBlock):
     blocktype = "ms"
     name = "Mass spectrometry"
     description = "Read and visualize mass spectrometry data as a grid plot per channel"
-    accepted_file_extensions = (".asc",)
+    accepted_file_extensions = (".asc", ".txt")
 
     @property
     def plot_functions(self):


### PR DESCRIPTION
Blocked by #719; we should allow txt files for the MS block (not sure why it was disabled).