### PR TITLE
Make account status on registration be configurable by provider

### DIFF
--- a/pydatalab/pydatalab/config.py
+++ b/pydatalab/pydatalab/config.py
@@ -192,9 +192,14 @@ class ServerConfig(BaseSettings):
         None, description="A dictionary containing metadata to serve at `/info`."
     )
 
+    ORCID_AUTO_ACTIVATE_ACCOUNTS: bool = Field(
+        False,
+        description="Whether to automatically activate accounts created via ORCID registration.",
+    )
+
     EMAIL_DOMAIN_ALLOW_LIST: Optional[List[str]] = Field(
         [],
-        description="A list of domains for which user's will be able to register accounts if they have a matching email address. Setting the value to `None` will allow any email addresses at any domain to register an account, otherwise the default `[]` will not allow any email addresses.",
+        description="A list of domains for which users will be able to register accounts if they have a matching verified email address, which still need to be verified by an admin. Setting the value to `None` will allow any email addresses at any domain to register *and activate* an account, otherwise the default `[]` will not allow any email addresses registration.",
     )
 
     EMAIL_AUTH_SMTP_SETTINGS: Optional[SMTPSettings] = Field(

--- a/pydatalab/pydatalab/models/people.py
+++ b/pydatalab/pydatalab/models/people.py
@@ -132,7 +132,10 @@ class Person(Entry):
 
     @staticmethod
     def new_user_from_identity(
-        identity: Identity, use_display_name: bool = True, use_contact_email: bool = True
+        identity: Identity,
+        use_display_name: bool = True,
+        use_contact_email: bool = True,
+        account_status: AccountStatus = AccountStatus.UNVERIFIED,
     ) -> "Person":
         """Create a new `Person` object with the given identity.
 
@@ -143,6 +146,7 @@ class Person(Entry):
             use_contact_email: If the identity provided is an email address,
                 this argument decides whether to populate the top-level
                 `contact_email` field with the address of this identity.
+            account_status: The starting account status of the user.
 
         Returns:
             A `Person` object with only the provided identity.
@@ -163,4 +167,5 @@ class Person(Entry):
             identities=[identity],
             display_name=display_name,
             contact_email=contact_email,
+            account_status=account_status,
         )

--- a/pydatalab/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/pydatalab/routes/v0_1/auth.py
@@ -26,7 +26,7 @@ from pydatalab.config import CONFIG
 from pydatalab.errors import UserRegistrationForbidden
 from pydatalab.logger import LOGGER, logged_route
 from pydatalab.login import get_by_id
-from pydatalab.models.people import Identity, IdentityType, Person
+from pydatalab.models.people import AccountStatus, Identity, IdentityType, Person
 from pydatalab.mongo import flask_mongo, insert_pydantic_model_fork_safe
 from pydatalab.send_email import send_mail
 
@@ -64,10 +64,14 @@ requests out to the providers.
 """
 
 
-def _check_email_domain(email: str, allow_list: Optional[list[str]]) -> bool:
+def _check_email_domain(email: str, allow_list: list[str] | None) -> bool:
     """Checks whether the provided email address is allowed to
-    register an account based on the configured domain allow list. If the user already exists,
-    they will be allowed to login either way.
+    register an account based on the configured domain allow list.
+
+    If the configured allow list is None, any email address is allowed to register.
+    If it is an empty list, no email addresses are allowed to register.
+
+    If the user already exists, they will be allowed to login either way.
 
     Parameters:
         email: The email address to check.
@@ -78,8 +82,11 @@ def _check_email_domain(email: str, allow_list: Optional[list[str]]) -> bool:
 
     """
     domain = email.split("@")[-1]
-    if allow_list is None:
+    if isinstance(allow_list, list) and not allow_list:
         return False
+
+    if allow_list is None:
+        return True
 
     for allowed in allow_list:
         if domain.endswith(allowed):
@@ -139,7 +146,7 @@ def find_create_or_modify_user(
     identity_name: str,
     display_name: Optional[str] = None,
     verified: bool = False,
-    create_account: bool = False,
+    create_account: bool | AccountStatus = False,
 ) -> None:
     """Search for a user account with the given identifier and identity type, creating
     or connecting one if it does not exist.
@@ -223,7 +230,14 @@ def find_create_or_modify_user(
             if not create_account:
                 raise UserRegistrationForbidden
 
-            user = Person.new_user_from_identity(identity, use_display_name=True)
+            if isinstance(create_account, bool):
+                account_status = AccountStatus.UNVERIFIED
+            else:
+                account_status = create_account
+
+            user = Person.new_user_from_identity(
+                identity, use_display_name=True, account_status=account_status
+            )
             LOGGER.debug("Inserting new user model %s into database", user)
             insert_pydantic_model_fork_safe(user, "users")
             user_model = get_by_id(str(user.immutable_id))
@@ -349,13 +363,26 @@ def email_logged_in():
     if not email:
         raise RuntimeError("No email found; please request a new token.")
 
+    # If the email domain list is explicitly configured to None, this allows any
+    # email address to make an active account, otherwise the email domain must match
+    # the list of allowed domains and the admin must verify the user
+    allowed = _check_email_domain(email, CONFIG.EMAIL_DOMAIN_ALLOW_LIST)
+    if not allowed:
+        # If this point is reached, the token is valid but the server settings have
+        # changed since the link was generated, so best to fail safe
+        raise UserRegistrationForbidden
+
+    create_account = AccountStatus.UNVERIFIED
+    if CONFIG.EMAIL_DOMAIN_ALLOW_LIST is None:
+        create_account = AccountStatus.ACTIVE
+
     find_create_or_modify_user(
         email,
         IdentityType.EMAIL,
         email,
         display_name=email,
         verified=True,
-        create_account=True,
+        create_account=create_account,
     )
 
     referer = request.headers.get("Referer", "/")
@@ -383,14 +410,15 @@ def github_logged_in(blueprint, token):
     username = str(github_info["login"])
     name = str(github_info["name"] if github_info["name"] is not None else github_info["login"])
 
-    create_account: bool = False
+    create_account: bool | AccountStatus = False
     # Use the read:org scope to check if the user is a member of at least one of the allowed orgs
     if CONFIG.GITHUB_ORG_ALLOW_LIST:
         for org in CONFIG.GITHUB_ORG_ALLOW_LIST:
             if str(int(org)) == org:
                 org = int(org)
             if blueprint.session.get(f"/orgs/{org}/members/{username}").ok:
-                create_account = True
+                # If this person has a GH account on the org allow list, activate their account
+                create_account = AccountStatus.ACTIVE
                 break
 
     elif CONFIG.GITHUB_ORG_ALLOW_LIST is None:
@@ -420,16 +448,18 @@ def orcid_logged_in(_, token):
     if not token:
         return False
 
+    # New ORCID accounts must be activated by an admin unless configured otherwise
+    create_account = AccountStatus.UNVERIFIED
+    if CONFIG.ORCID_AUTO_ACTIVATE_ACCOUNTS:
+        create_account = AccountStatus.ACTIVE
+
     find_create_or_modify_user(
         token["orcid"],
         IdentityType.ORCID,
         token["orcid"],
         display_name=token["name"],
         verified=True,
-        # TODO: For now, this does not create a new user account if missing, but can be used
-        # to connect an existing user account with an ORCID identity (which can then be used
-        # for login).
-        create_account=False,
+        create_account=create_account,
     )
 
     # Return false to prevent Flask-dance from trying to store the token elsewhere

--- a/pydatalab/tests/server/test_auth.py
+++ b/pydatalab/tests/server/test_auth.py
@@ -7,8 +7,8 @@ def test_allow_emails():
     assert _check_email_domain("test@example.org", ["example.org", "example2.org"])
     assert _check_email_domain("test@subdomain.example.org", ["example.org", "example2.org"])
     assert _check_email_domain("test@subdomain.example.org", ["subdomain.example.org"])
-    assert _check_email_domain("test@example2.org", [])
-    assert not _check_email_domain("test@example2.org", None)
+    assert not _check_email_domain("test@example2.org", [])
+    assert _check_email_domain("test@example2.org", None)
     assert not _check_email_domain("test@example.org", ["subdomain.example.org"])
     assert not _check_email_domain("test@example2.org", ["example.org"])
 


### PR DESCRIPTION
This PR updates our account registration workflow so that we can have the following behavior for our supported OAuth providers:

- If a GitHub allowed org is configured, nothing has changed, and a user can register and have their account activated automatically
- If `ORCID_AUTO_ACTIVATE_ACCOUNTS` is enabled, when someone registers via ORCID, their account is automatically activated. Otherwise, an admin must approve it.
- If `EMAIL_DOMAIN_ALLOW_LIST` is configured explicitly to `None`, then any address can automatically register an active account. Otherwise, if configured to `[]`, then no-one can register, and if configured to a set of domains, registration will require admin approval.

The main change here is that ORCID auth will now register an account in the default implementation, rather than relying on patches to specific deployments.