### PR TITLE
Revert pre-commit autoupdate for prettier

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,7 +32,7 @@ repos:
       - id: ruff-format
 
   - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: v4.0.0-alpha.8
+    rev: v3.1.0
     hooks:
       - id: prettier
         types_or: [javascript, jsx, vue, html, yaml]


### PR DESCRIPTION
Merged #728 too hastily. We need to prevent pre-commit from automatically using prettier-4, which for me seems quite broken.