### PR TITLE
Fix styling of StyledInput 

### DIFF
--- a/webapp/src/components/EditAccountSettingsModal.vue
+++ b/webapp/src/components/EditAccountSettingsModal.vue
@@ -100,7 +100,12 @@
           <div class="form-group col-md-12">
             <label for="api-key" class="col-form-label">API Key:</label>
             <div v-if="apiKeyDisplayed" class="input-group">
-              <StyledInput v-model="apiKey" :readonly="true" :helpMessage="apiKeyHelpMessage" />
+              <StyledInput
+                v-model="apiKey"
+                :readonly="true"
+                :forceFormControl="true"
+                :helpMessage="apiKeyHelpMessage"
+              />
               <div class="input-group-append">
                 <button class="btn btn-outline-secondary" type="button" @click="copyToClipboard">
                   <font-awesome-icon icon="copy" />

--- a/webapp/src/components/EditAccountSettingsModal.vue
+++ b/webapp/src/components/EditAccountSettingsModal.vue
@@ -102,9 +102,9 @@
             <div v-if="apiKeyDisplayed" class="input-group">
               <StyledInput
                 v-model="apiKey"
-                :readonly="true"
-                :forceFormControl="true"
                 :helpMessage="apiKeyHelpMessage"
+                readonly
+                class="form-control"
               />
               <div class="input-group-append">
                 <button class="btn btn-outline-secondary" type="button" @click="copyToClipboard">

--- a/webapp/src/components/StartingMaterialInformation.vue
+++ b/webapp/src/components/StartingMaterialInformation.vue
@@ -8,11 +8,21 @@
       </div>
       <div class="form-group col-md-2 col-sm-3 col-6">
         <label for="startmat-item_id">Item ID</label>
-        <StyledInput id="startmat-item_id" readonly :modelValue="ItemID" />
+        <StyledInput
+          id="startmat-item_id"
+          readonly
+          class="form-control-plaintext"
+          :modelValue="ItemID"
+        />
       </div>
       <div class="form-group col-lg-7 col-md-8 col-sm-6">
         <label for="startmat-name">Name</label>
-        <StyledInput id="startmat-name" v-model="Name" :readonly="!isEditable" />
+        <StyledInput
+          id="startmat-name"
+          v-model="Name"
+          :class="{ 'form-control': isEditable, 'form-control-plaintext': !isEditable }"
+          :readonly="!isEditable"
+        />
       </div>
     </div>
     <div class="form-row">
@@ -25,11 +35,21 @@
       </div>
       <div class="form-group col-lg-3 col-sm-4">
         <label for="startmat-supplier">Supplier</label>
-        <StyledInput id="startmat-supplier" v-model="Supplier" :readonly="!isEditable" />
+        <StyledInput
+          id="startmat-supplier"
+          v-model="Supplier"
+          :class="{ 'form-control': isEditable, 'form-control-plaintext': !isEditable }"
+          :readonly="!isEditable"
+        />
       </div>
       <div class="form-group col-lg-3 col-sm-4">
         <label for="startmat-purity">Chemical purity</label>
-        <StyledInput id="startmat-purity" v-model="ChemicalPurity" :readonly="!isEditable" />
+        <StyledInput
+          id="startmat-purity"
+          v-model="ChemicalPurity"
+          :class="{ 'form-control': isEditable, 'form-control-plaintext': !isEditable }"
+          :readonly="!isEditable"
+        />
       </div>
     </div>
     <div class="form-row">
@@ -39,6 +59,7 @@
           id="startmat-date-acquired"
           type="date"
           v-model="DateAcquired"
+          :class="{ 'form-control': isEditable, 'form-control-plaintext': !isEditable }"
           :readonly="!isEditable"
         />
       </div>
@@ -48,23 +69,39 @@
           id="startmat-date-opened"
           type="date"
           v-model="DateOpened"
+          :class="{ 'form-control': isEditable, 'form-control-plaintext': !isEditable }"
           :readonly="!isEditable"
         />
       </div>
       <div class="form-group col-lg-3 col-sm-4">
         <label for="startmat-location">Location</label>
-        <StyledInput id="startmat-location" v-model="Location" :readonly="!isEditable" />
+        <StyledInput
+          id="startmat-location"
+          v-model="Location"
+          :class="{ 'form-control': isEditable, 'form-control-plaintext': !isEditable }"
+          :readonly="!isEditable"
+        />
       </div>
     </div>
 
     <div class="form-row">
       <div class="form-group col-lg-3 col-sm-4">
         <label for="startmat-cas">CAS</label>
-        <StyledInput id="startmat-cas" v-model="CAS" :readonly="!isEditable" />
+        <StyledInput
+          id="startmat-cas"
+          v-model="CAS"
+          :class="{ 'form-control': isEditable, 'form-control-plaintext': !isEditable }"
+          :readonly="!isEditable"
+        />
       </div>
       <div class="form-group col-lg-3 col-sm-4">
         <label for="startmat-hazards">GHS Hazard Codes</label>
-        <StyledInput id="startmat-hazards" v-model="GHS" :readonly="!isEditable" />
+        <StyledInput
+          id="startmat-hazards"
+          v-model="GHS"
+          :class="{ 'form-control': isEditable, 'form-control-plaintext': !isEditable }"
+          :readonly="!isEditable"
+        />
       </div>
       <div class="col-lg-3 col-sm-4">
         <ToggleableCollectionFormGroup v-model="Collections" />

--- a/webapp/src/components/StyledInput.vue
+++ b/webapp/src/components/StyledInput.vue
@@ -2,7 +2,7 @@
   <input
     ref="input"
     :type="inputType"
-    :class="{ 'form-control': !readonly, 'form-control': readonly }"
+    :class="{ 'form-control': !readonly, 'form-control-plaintext': readonly }"
     :readonly="readonly"
     v-model="vmodelvalue"
     @mouseenter="delayedShowTooltip"
@@ -97,10 +97,6 @@ export default {
 </script>
 
 <style scoped>
-input {
-  border: 1px solid grey;
-}
-
 #tooltip {
   z-index: 9999;
   border: 1px solid grey;

--- a/webapp/src/components/StyledInput.vue
+++ b/webapp/src/components/StyledInput.vue
@@ -2,7 +2,10 @@
   <input
     ref="input"
     :type="inputType"
-    :class="{ 'form-control': !readonly, 'form-control-plaintext': readonly }"
+    :class="{
+      'form-control': !readonly || forceFormControl,
+      'form-control-plaintext': readonly && !forceFormControl,
+    }"
     :readonly="readonly"
     v-model="vmodelvalue"
     @mouseenter="delayedShowTooltip"
@@ -32,6 +35,10 @@ export default {
     },
     type: { default: "string" },
     helpMessage: { type: String },
+    forceFormControl: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {

--- a/webapp/src/components/StyledInput.vue
+++ b/webapp/src/components/StyledInput.vue
@@ -1,20 +1,19 @@
 <template>
-  <input
-    ref="input"
-    :type="inputType"
-    :class="{
-      'form-control': !readonly || forceFormControl,
-      'form-control-plaintext': readonly && !forceFormControl,
-    }"
-    :readonly="readonly"
-    v-model="vmodelvalue"
-    @mouseenter="delayedShowTooltip"
-    @mouseleave="hideTooltip"
-    @focus="delayedShowTooltip"
-    @blur="hideTooltip"
-  />
-  <div ref="tooltipContent" id="tooltip" role="tooltip">
-    {{ helpMessage }}
+  <div class="flex-grow-1">
+    <input
+      ref="input"
+      :type="inputType"
+      :readonly="readonly"
+      v-model="vmodelvalue"
+      v-bind="$attrs"
+      @mouseenter="delayedShowTooltip"
+      @mouseleave="hideTooltip"
+      @focus="delayedShowTooltip"
+      @blur="hideTooltip"
+    />
+    <div ref="tooltipContent" id="tooltip" role="tooltip">
+      {{ helpMessage }}
+    </div>
   </div>
 </template>
 
@@ -27,18 +26,11 @@ import { createPopper } from "@popperjs/core";
 // (but, the time is discarded!)
 
 export default {
+  inheritAttrs: false,
   props: {
     modelValue: { default: "" },
-    readonly: {
-      type: Boolean,
-      default: false,
-    },
     type: { default: "string" },
     helpMessage: { type: String },
-    forceFormControl: {
-      type: Boolean,
-      default: false,
-    },
   },
   data() {
     return {
@@ -49,7 +41,7 @@ export default {
   },
   computed: {
     inputType() {
-      if (this.readonly && (this.type == "date" || this.type == "datetime-local")) {
+      if (this.$attrs.readonly && (this.type == "date" || this.type == "datetime-local")) {
         return "text";
       }
       return this.type;


### PR DESCRIPTION
Recent changes to StyledInput in #706 have broken the display on the StartingMaterialInformation page by removing the bootstrap form-control class. This PR reverts the changes.