### PR TITLE
Add block help to block title

### DIFF
--- a/webapp/src/components/StyledBlockHelp.vue
+++ b/webapp/src/components/StyledBlockHelp.vue
@@ -1,5 +1,5 @@
 <template>
-    <a
+  <a
     ref="anchor"
     class="dropdown-item"
     @mouseenter="delayedShowTooltip"

--- a/webapp/src/components/StyledBlockInfo.vue
+++ b/webapp/src/components/StyledBlockInfo.vue
@@ -1,26 +1,32 @@
 <template>
-    <a
+  <a
     ref="anchor"
-    class="dropdown-item"
     @mouseenter="delayedShowTooltip"
     @mouseleave="hideTooltip"
     @focus="delayedShowTooltip"
     @blur="hideTooltip"
-    >{{ blockInfo.name }}</a
   >
+    <font-awesome-icon :icon="['fas', 'info-circle']" @click="showBlockInfo" />
+  </a>
   <div ref="tooltipContent" id="tooltip" role="tooltip">
-    <p>{{ blockInfo.description }}</p>
-    <p
-      class="accepted-file"
+    <h4 class="block-info-title">{{ blockInfo.attributes.name }}</h4>
+    <p>{{ blockInfo.attributes.description }}</p>
+    <div
       v-if="
-        blockInfo.accepted_file_extensions != null && blockInfo.accepted_file_extensions.length > 0
+        blockInfo.attributes.accepted_file_extensions != null &&
+        blockInfo.attributes.accepted_file_extensions.length > 0
       "
     >
       Accepted file extensions:
-      <span v-for="(extension, index) in blockInfo.accepted_file_extensions" :key="index">
-        {{ extension }}{{ index < blockInfo.accepted_file_extensions.length - 1 ? ", " : "" }}
-      </span>
-    </p>
+      <ul>
+        <span
+          v-for="(extension, index) in blockInfo.attributes.accepted_file_extensions"
+          :key="index"
+        >
+          <li class="filetype-li">{{ extension }}</li>
+        </span>
+      </ul>
+    </div>
   </div>
 </template>
 
@@ -28,7 +34,7 @@
 import { createPopper } from "@popperjs/core";
 
 export default {
-  name: "StyledBlockHelp",
+  name: "StyledBlockInfo",
   props: {
     blockInfo: {
       type: Object,
@@ -48,7 +54,7 @@ export default {
           this.$refs.tooltipContent.setAttribute("data-show", "");
           this.popperInstance.update();
         }
-      }, 500);
+      }, 100);
     },
 
     hideTooltip() {
@@ -84,20 +90,24 @@ input {
 #tooltip {
   z-index: 9999;
   border: 1px solid grey;
-  width: auto;
+  width: 25%;
   background: #333;
+  box-shadow: 0 0 10px cornflowerblue;
   color: white;
   font-weight: bold;
   padding: 1em;
   border-radius: 4px;
 }
 
-#tooltip p {
-  margin: 0;
+.block-info-title {
+  /* add wavy blue underline */
+  text-decoration: underline;
+  text-decoration-color: cornflowerblue;
+  text-decoration-style: wavy;
 }
 
-.accepted-file {
-  padding-top: 0.5em;
+.filetype-li {
+  font-family: "Roboto Mono", monospace;
 }
 
 #tooltip {

--- a/webapp/src/components/datablocks/CycleBlock.vue
+++ b/webapp/src/components/datablocks/CycleBlock.vue
@@ -5,7 +5,7 @@
         v-model="file_id"
         :item_id="item_id"
         :block_id="block_id"
-        :extensions="['.mpr', '.txt', '.xls', '.xlsx', '.txt', '.res', '.nda', '.ndax']"
+        :extensions="blockInfo.attributes.accepted_file_extensions"
         updateBlockOnChange
       />
     </div>
@@ -183,6 +183,9 @@ export default {
     },
     isUpdating() {
       return this.$store.state.updating[this.block_id];
+    },
+    blockInfo() {
+      return this.$store.state.blocksInfos["cycle"];
     },
     // normalizingMass() {
     //   return this.$store.all_item_data[this.item_id]["characteristic_mass"] || null;

--- a/webapp/src/components/datablocks/DataBlockBase.vue
+++ b/webapp/src/components/datablocks/DataBlockBase.vue
@@ -9,6 +9,7 @@
       />
       <input class="form-control-plaintext block-title" type="text" v-model="BlockTitle" />
       <span class="blocktype-label ml-auto mr-3">{{ blockType }}</span>
+      <span class="block-header-icon"><StyledBlockInfo :blockInfo="blockInfo" /></span>
       <font-awesome-icon
         :icon="['fa', 'sync']"
         class="block-header-icon"
@@ -81,6 +82,7 @@
  */
 import { createComputedSetterForBlockField } from "@/field_utils.js";
 import TinyMceInline from "@/components/TinyMceInline";
+import StyledBlockInfo from "@/components/StyledBlockInfo";
 import tinymce from "tinymce/tinymce";
 
 import { deleteBlock, updateBlockFromServer } from "@/server_fetch_utils";
@@ -113,6 +115,9 @@ export default {
     },
     isUpdating() {
       return this.$store.state.updatingDelayed[this.block_id];
+    },
+    blockInfo() {
+      return this.$store.state.blocksInfos[this.blockType];
     },
     BlockTitle: createComputedSetterForBlockField("title"),
     BlockDescription: createComputedSetterForBlockField("freeform_comment"),
@@ -179,6 +184,7 @@ export default {
   },
   components: {
     TinyMceInline,
+    StyledBlockInfo,
   },
 };
 </script>

--- a/webapp/src/components/datablocks/EISBlock.vue
+++ b/webapp/src/components/datablocks/EISBlock.vue
@@ -6,7 +6,7 @@ DataBlockBase as a prop, and save from within DataBlockBase  -->
       v-model="file_id"
       :item_id="item_id"
       :block_id="block_id"
-      :extensions="['.txt']"
+      :extensions="blockInfo.attributes.accepted_file_extensions"
       updateBlockOnChange
     />
 
@@ -37,6 +37,9 @@ export default {
         .bokeh_plot_data;
     },
     file_id: createComputedSetterForBlockField("file_id"),
+    blockInfo() {
+      return this.$store.state.blocksInfos["eis"];
+    },
   },
   components: {
     DataBlockBase,

--- a/webapp/src/components/datablocks/MassSpecBlock.vue
+++ b/webapp/src/components/datablocks/MassSpecBlock.vue
@@ -6,7 +6,7 @@ DataBlockBase as a prop, and save from within DataBlockBase  -->
       v-model="file_id"
       :item_id="item_id"
       :block_id="block_id"
-      :extensions="['.asc']"
+      :extensions="blockInfo.attributes.accepted_file_extensions"
       updateBlockOnChange
     />
 
@@ -35,6 +35,9 @@ export default {
     bokehPlotData() {
       return this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id]
         .bokeh_plot_data;
+    },
+    blockInfo() {
+      return this.$store.state.blocksInfos["tga"];
     },
     file_id: createComputedSetterForBlockField("file_id"),
   },

--- a/webapp/src/components/datablocks/MediaBlock.vue
+++ b/webapp/src/components/datablocks/MediaBlock.vue
@@ -4,7 +4,7 @@
       v-model="file_id"
       :item_id="item_id"
       :block_id="block_id"
-      :extensions="['.png', '.jpeg', '.jpg', '.tiff', '.tif', '.mp4', '.mov', '.webm']"
+      :extensions="blockInfo.attributes.accepted_file_extensions"
       class="mb-3"
       updateBlockOnChange
     />
@@ -31,6 +31,9 @@ export default {
     },
     block_data() {
       return this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id];
+    },
+    blockInfo() {
+      return this.$store.state.blocksInfos["media"];
     },
     media_url() {
       // If the API has already base64 encoded the image, then use it,

--- a/webapp/src/components/datablocks/NMRBlock.vue
+++ b/webapp/src/components/datablocks/NMRBlock.vue
@@ -6,7 +6,7 @@ DataBlockBase as a prop, and save from within DataBlockBase  -->
       v-model="file_id"
       :item_id="item_id"
       :block_id="block_id"
-      :extensions="['.zip']"
+      :extensions="blockInfo.attributes.accepted_file_extensions"
       updateBlockOnChange
     />
     <div v-show="file_id">
@@ -130,6 +130,9 @@ export default {
     bokehPlotData() {
       return this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id]
         .bokeh_plot_data;
+    },
+    blockInfo() {
+      return this.$store.state.blocksInfos["nmr"];
     },
     file_id: createComputedSetterForBlockField("file_id"),
     selected_process: createComputedSetterForBlockField("selected_process"),

--- a/webapp/src/components/datablocks/RamanBlock.vue
+++ b/webapp/src/components/datablocks/RamanBlock.vue
@@ -6,7 +6,7 @@ DataBlockBase as a prop, and save from within DataBlockBase  -->
       v-model="file_id"
       :item_id="item_id"
       :block_id="block_id"
-      :extensions="['.txt', '.wdf']"
+      :extensions="blockInfo.attributes.accepted_file_extensions"
       updateBlockOnChange
     />
 
@@ -35,6 +35,9 @@ export default {
     bokehPlotData() {
       return this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id]
         .bokeh_plot_data;
+    },
+    blockInfo() {
+      return this.$store.state.blocksInfos["raman"];
     },
     file_id: createComputedSetterForBlockField("file_id"),
   },

--- a/webapp/src/components/datablocks/XRDBlock.vue
+++ b/webapp/src/components/datablocks/XRDBlock.vue
@@ -7,7 +7,7 @@ DataBlockBase as a prop, and save from within DataBlockBase  -->
         v-model="file_id"
         :item_id="item_id"
         :block_id="block_id"
-        :extensions="['.xrdml', '.xy', '.dat', '.xye']"
+        :extensions="blockInfo.attributes.accepted_file_extensions"
         updateBlockOnChange
       />
     </div>
@@ -67,6 +67,9 @@ export default {
     bokehPlotData() {
       return this.$store.state.all_item_data[this.item_id]["blocks_obj"][this.block_id]
         .bokeh_plot_data;
+    },
+    blockInfo() {
+      return this.$store.state.blocksInfos["xrd"];
     },
     wavelength: createComputedSetterForBlockField("wavelength"),
     file_id: createComputedSetterForBlockField("file_id"),


### PR DESCRIPTION
This PR extends #719 by adding an info hover to the block title itself, and uses the block info data to populate the `accepted_file_extensions` dynamically.

You can see the tweaks needed on each block for this, which emphasizes the need for a refactor like in #616, which makes a less generic base block that can do e.g., file drop downs.