### PR TITLE
Fix StyledInput component (v2)

### DIFF
--- a/webapp/src/components/EditAccountSettingsModal.vue
+++ b/webapp/src/components/EditAccountSettingsModal.vue
@@ -100,7 +100,12 @@
           <div class="form-group col-md-12">
             <label for="api-key" class="col-form-label">API Key:</label>
             <div v-if="apiKeyDisplayed" class="input-group">
-              <StyledInput v-model="apiKey" :readonly="true" :helpMessage="apiKeyHelpMessage" />
+              <StyledInput
+                v-model="apiKey"
+                :readonly="true"
+                :helpMessage="apiKeyHelpMessage"
+                class="form-control"
+              />
               <div class="input-group-append">
                 <button class="btn btn-outline-secondary" type="button" @click="copyToClipboard">
                   <font-awesome-icon icon="copy" />

--- a/webapp/src/components/StyledInput.vue
+++ b/webapp/src/components/StyledInput.vue
@@ -2,13 +2,14 @@
   <input
     ref="input"
     :type="inputType"
-    :class="{ 'form-control': !readonly, 'form-control-plaintext': readonly }"
+    :class="formControlClass"
     :readonly="readonly"
     v-model="vmodelvalue"
     @mouseenter="delayedShowTooltip"
     @mouseleave="hideTooltip"
     @focus="delayedShowTooltip"
     @blur="hideTooltip"
+    v-bind="$attrs"
   />
   <div ref="tooltipContent" id="tooltip" role="tooltip">
     {{ helpMessage }}
@@ -46,6 +47,16 @@ export default {
         return "text";
       }
       return this.type;
+    },
+    formControlClass() {
+      // If the component $attrs specify "form-control" or "form-control-plaintext",
+      // don't set any class. Otherwise, set the appropriate class based on whether
+      // readonly is specified
+      const classes = this.$attrs.class ? this.$attrs.class.split(" ") : [];
+      if (classes.includes("form-control") || classes.includes("form-control-plaintext")) {
+        return "";
+      }
+      return this.readonly ? "form-control-plaintext" : "form-control";
     },
     vmodelvalue: {
       get() {

--- a/webapp/src/components/StyledInput.vue
+++ b/webapp/src/components/StyledInput.vue
@@ -2,7 +2,7 @@
   <input
     ref="input"
     :type="inputType"
-    :class="{ 'form-control': !readonly, 'form-control': readonly }"
+    :class="{ 'form-control': !readonly, 'form-control-plaintext': readonly }"
     :readonly="readonly"
     v-model="vmodelvalue"
     @mouseenter="delayedShowTooltip"
@@ -97,10 +97,6 @@ export default {
 </script>
 
 <style scoped>
-input {
-  border: 1px solid grey;
-}
-
 #tooltip {
   z-index: 9999;
   border: 1px solid grey;


### PR DESCRIPTION
Recent changes to StyledInput in https://github.com/the-grey-group/datalab/pull/706 inadvertently broke the display on the StartingMaterialInformation page by removing the bootstrap form-control class. This PR reverts this change so that `form-control-plaintext` is automatically set on readonly instances of StyledInput, and `form-control` is set on non-readonly instances.

However, this behavior can now be overwritten by directly providing one of these two classes to the StyledInput component, e.g. :

```js
<StyledInput readonly class="form-control">
```

This PR replaces #735.