### PR TITLE
Tweak mount points, production Docker entrypoint and development environment

### DIFF
--- a/.docker/app_dockerfile
+++ b/.docker/app_dockerfile
@@ -30,6 +30,7 @@ ARG VUE_APP_API_URL=magic-api-url
 ARG VUE_APP_LOGO_URL=magic-logo-url
 ARG VUE_APP_HOMEPAGE_URL=magic-homepage-url
 ARG VUE_APP_EDITABLE_INVENTORY=magic-setting
+ARG VUE_APP_WEBSITE_TITLE=magic-title
 
 COPY webapp ./
 RUN /node_modules/.bin/vue-cli-service build

--- a/.docker/app_entrypoint.sh
+++ b/.docker/app_entrypoint.sh
@@ -24,15 +24,18 @@ echo ""
 echo "  API_URL: ${VUE_APP_API_URL}"
 echo "  LOGO_URL: ${VUE_APP_LOGO_URL}"
 echo "  HOMEPAGE_URL: ${VUE_APP_HOMPAGE_URL}"
+echo "  EDITABLE_INVENTORY: ${VUE_APP_EDITABLE_INVENTORY}"
+echo "  WEBSITE_TITLE: ${VUE_APP_WEBSITE_TITLE}"
 echo ""
 echo "Patching..."
 
-for file in $ROOT_DIR/js/app.*.js*; do
+for file in $ROOT_DIR/js/app.*.js* $ROOT_DIR/*html; do
     echo "$file"
     sed -i "s|magic-api-url|${VUE_APP_API_URL}|g" $file
     sed -i "s|magic-logo-url|${VUE_APP_LOGO_URL}|g" $file
     sed -i "s|magic-homepage-url|${VUE_APP_HOMEPAGE_URL}|g" $file
     sed -i "s|magic-setting|${VUE_APP_EDITABLE_INVENTORY}|g" $file
+    sed -i "s|magic-title|${VUE_APP_WEBSITE_TITLE}|g" $file
     done
 
 echo "Done!"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,7 +57,7 @@ services:
       dockerfile: .docker/server_dockerfile
       target: development
     depends_on:
-      - database
+      - database_dev
     volumes:
       - ./logs:/logs
       - ./pydatalab:/app
@@ -67,9 +67,23 @@ services:
       - backend
     environment:
       - PYDATALAB_TESTING=true
-      - PYDATALAB_MONGO_URI=mongodb://database:27017/datalabvue
+      - PYDATALAB_MONGO_URI=mongodb://database_dev:27017/datalabvue
+
+  database_dev:
+    profiles: ["dev"]
+    build:
+      context: .
+      dockerfile: .docker/mongo_dockerfile
+    volumes:
+      - ./logs:/var/logs/mongod
+    restart: always
+    networks:
+      - backend
+    ports:
+      - "27017:27017"
 
   database:
+    profiles: ["prod"]
     build:
       context: .
       dockerfile: .docker/mongo_dockerfile
@@ -79,8 +93,6 @@ services:
     restart: always
     networks:
       - backend
-    ports:
-      - "27017:27017"
 
 networks:
   backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,7 @@ services:
     volumes:
       - ./logs:/logs
       - /data/files:/app/files
-      - /data/backups:/data/backups
+      - /data/backups:/tmp/datalab-backups
     ports:
       - "5001:5001"
     networks:

--- a/pydatalab/pydatalab/config.py
+++ b/pydatalab/pydatalab/config.py
@@ -225,19 +225,19 @@ its importance when deploying a datalab instance.""",
         {
             "daily-snapshots": BackupStrategy(
                 hostname=None,
-                location="/tmp/daily-snapshots/",
+                location="/tmp/datalab-backups/daily-snapshots/",
                 frequency="5 4 * * *",  # 4:05 every day
                 retention=7,
             ),
             "weekly-snapshots": BackupStrategy(
                 hostname=None,
-                location="/tmp/weekly-snapshots/",
+                location="/tmp/datalab-backups/weekly-snapshots/",
                 frequency="5 3 * * 1",  # 03:05 every Monday
                 retention=5,
             ),
             "quarterly-snapshots": BackupStrategy(
                 hostname=None,
-                location="/tmp/quarterly-snapshots/",
+                location="/tmp/datalab-backups/quarterly-snapshots/",
                 frequency="5 2 1 1,4,7,10 *",  # first of January, April, July, October at 02:05
                 retention=4,
             ),


### PR DESCRIPTION
Closes #757
Closes #755 

- Updates the default backup location to a point that is definitely safely mounted (`/tmp/backups/` rather than just `/tmp`).
- Hot patches the API URL setting in the production container build
- Add a new `database_dev` service in docker-compose that doesn't require root access to run (by not mounting at `/data/db`).