### PR TITLE
Default to ORCID ID as display name when ORCID user's name is private

### DIFF
--- a/pydatalab/pydatalab/routes/v0_1/auth.py
+++ b/pydatalab/pydatalab/routes/v0_1/auth.py
@@ -459,7 +459,7 @@ def orcid_logged_in(_, token):
         token["orcid"],
         IdentityType.ORCID,
         token["orcid"],
-        display_name=token["name"],
+        display_name=token.get("name", token["orcid"]),
         verified=True,
         create_account=create_account,
     )


### PR DESCRIPTION
Closes #761.