### PR TITLE
Follow new auth requirements in UI tables

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,8 +147,9 @@ jobs:
         run: |
           # Add default API URL argument to Vue prod build
           echo "VUE_APP_API_URL=http://localhost:5001" >> .env
+          echo "PYDATALAB_TESTING=true" >> .env
           # Launch production container profiles and wait for them to come up
-          docker compose up database api_dev app -d --wait
+          docker compose up database api app -d --wait
 
       - name: Run end-to-end tests
         uses: cypress-io/github-action@v6

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,7 +147,7 @@ jobs:
         run: |
           # Add default API URL argument to Vue prod build
           echo "VUE_APP_API_URL=http://localhost:5001" >> .env
-          echo "PYDATALAB_TESTING=true" >> .env
+          echo "PYDATALAB_TESTING=true" >> pydatalab/.env
           # Launch production container profiles and wait for them to come up
           docker compose up database api app -d --wait
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -66,7 +66,6 @@ services:
     networks:
       - backend
     environment:
-      - PYDATALAB_TESTING=true
       - PYDATALAB_MONGO_URI=mongodb://database_dev:27017/datalabvue
 
   database_dev:

--- a/webapp/src/components/FancyStartingMaterialTable.vue
+++ b/webapp/src/components/FancyStartingMaterialTable.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isFetchError" class="alert alert-danger">
-    <font-awesome-icon icon="exclamation-circle" />&nbsp;Inventory could not be retreived. Are you
-    logged in?
+    <font-awesome-icon icon="exclamation-circle" />&nbsp;Server error: inventory could not be
+    retrieved.
   </div>
   <div class="form-inline ml-auto col-3 mb-2">
     <div class="form-group">

--- a/webapp/src/components/Navbar.vue
+++ b/webapp/src/components/Navbar.vue
@@ -18,6 +18,11 @@
       ><font-awesome-icon icon="project-diagram" />&nbsp;Graph View</router-link
     >
   </div>
+  <div v-if="!isLoggedIn" class="container">
+    <div class="alert alert-info col-md-6 col-lg-4 text-center mx-auto">
+      Please login to view or create items.
+    </div>
+  </div>
 </template>
 
 <script>
@@ -33,6 +38,11 @@ export default {
       homepage_url: HOMEPAGE_URL,
       user: null,
     };
+  },
+  computed: {
+    isLoggedIn() {
+      return Boolean(this.$store.state.currentUserDisplayName);
+    },
   },
   components: {
     LoginDetails,

--- a/webapp/src/components/StartingMaterialTable.vue
+++ b/webapp/src/components/StartingMaterialTable.vue
@@ -1,7 +1,7 @@
 <template>
   <div v-if="isFetchError" class="alert alert-danger">
-    <font-awesome-icon icon="exclamation-circle" />&nbsp;Inventory could not be retreived. Are you
-    logged in?
+    <font-awesome-icon icon="exclamation-circle" />&nbsp;Server error: inventory could not be
+    retrieved.
   </div>
   <table class="table table-hover table-sm">
     <thead>

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -202,12 +202,17 @@ export async function getInfo() {
 export function getSampleList() {
   return fetch_get(`${API_URL}/samples/`)
     .then(function (response_json) {
+      console.log(response_json);
       store.commit("setSampleList", response_json.samples);
     })
     .catch((error) => {
-      console.error("Error when fetching sample list");
-      console.error(error);
-      throw error;
+      if (error === "UNAUTHORIZED") {
+        store.commit("setSampleList", []);
+      } else {
+        console.error("Error when fetching sample list");
+        console.error(error);
+        throw error;
+      }
     });
 }
 
@@ -218,9 +223,16 @@ export function getCollectionSampleList(collection_id) {
       store.commit("setCollectionSampleList", response_json);
     })
     .catch((error) => {
-      console.error("Error when fetching collection sample list for collection_id", collection_id);
-      console.error(error);
-      throw error;
+      if (error === "UNAUTHORIZED") {
+        store.commit("setCollectionSampleList", []);
+      } else {
+        console.error(
+          "Error when fetching collection sample list for collection_id",
+          collection_id,
+        );
+        console.error(error);
+        throw error;
+      }
     });
 }
 
@@ -230,9 +242,13 @@ export function getCollectionList() {
       store.commit("setCollectionList", response_json.data);
     })
     .catch((error) => {
-      console.error("Error when fetching collection list");
-      console.error(error);
-      throw error;
+      if (error === "UNAUTHORIZED") {
+        store.commit("setCollectionList", []);
+      } else {
+        console.error("Error when fetching collection list");
+        console.error(error);
+        throw error;
+      }
     });
 }
 
@@ -258,9 +274,13 @@ export function getStartingMaterialList() {
       store.commit("setStartingMaterialList", response_json.items);
     })
     .catch((error) => {
-      console.error("Error when fetching starting material list");
-      console.error(error);
-      throw error;
+      if (error === "UNAUTHORIZED") {
+        store.commit("setStartingMaterialList", []);
+      } else {
+        console.error("Error when fetching starting material list");
+        console.error(error);
+        throw error;
+      }
     });
 }
 
@@ -270,9 +290,13 @@ export function getEquipmentList() {
       store.commit("setEquipmentList", response_json.items);
     })
     .catch((error) => {
-      console.error("Error when fetching equipment list");
-      console.error(error);
-      throw error;
+      if (error === "UNAUTHORIZED") {
+        store.commit("setEquipmentList", []);
+      } else {
+        console.error("Error when fetching equipment list");
+        console.error(error);
+        throw error;
+      }
     });
 }
 


### PR DESCRIPTION
i.e., do not show an error message if the API responds with unauthorized, just return a blank table.

At some point #675 will have to address this properly, as right now there is no longer a concept of anonymous, public samples (this will need to be patched explicitly on the public deployment) but it should be easier to transition from strict to looesr auth rather than the reverse (now that we are spreading).

As a side note, I have now disabled testing mode by default on the dev container, as it is now much more straightforward to do user management locally.

Hopefully this is the final PR before releasing!

Closes #762 