### PR TITLE
Changes to pre-commit 

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,8 @@ repos:
     rev: v1.10.0
     hooks:
       - id: mypy
-        additional_dependencies: ["types-all", "pydantic~=1.10"]
+        additional_dependencies:
+          ["types-python-dateutil", "types-requests", "types-paramiko", "pydantic~=1.10"]
 
   - repo: local
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -53,6 +53,6 @@ repos:
       - id: generate-schemas
         name: Regenerate item model JSONSchemas
         description: Check if the current code changes have enacted changes to the resulting JSONSchemas
-        entry: invoke -r pydatalab dev.generate-schemas
+        entry: bash -c "PIPENV_PIPFILE=pydatalab/Pipfile pipenv run invoke -r pydatalab dev.generate-schemas"
         pass_filenames: false
-        language: python
+        language: system


### PR DESCRIPTION
This PR (hopefully) fixes two issues with our pre-commit
1. The `generate-schemas` hook used `repo:local` and `language:python`, which allows it to run code within our pipenv. However, this means that if `pre-commit` is ever run from outside the pydatalab virtual environment, it will instead attempt to run the code in the system environment, and fail. This can happen if, for example, the user tries to run `git commit` without being in the pydatalab pipenv shell or typing `pipenv run git commit`. The change here uses the `language:system` option and a bash one-liner to manually ensure that `generate-schemas` is always run in the correct `pipenv`. 

3. Recently mypy started breaking with the mysterious `AssertionError: Internal error: unresolved placeholder type None`. This seems to be related to using the `type-all` requirement in our mypy pre-commit hook. Here, I replace it with explicity requirements for the type stubs we use:
   - `types-python-dateutil`
   - `types-requests`
   - `types-paramiko`
