### PR TITLE
Report runtime server config at `/info` and use this in UI

### DIFF
--- a/pydatalab/pydatalab/config.py
+++ b/pydatalab/pydatalab/config.py
@@ -329,3 +329,29 @@ CONFIG: ServerConfig = ServerConfig()
 """The global server configuration object.
 This is a singleton instance of the `ServerConfig` model.
 """
+
+
+class AuthMechanisms(BaseModel):
+    github: bool = False
+    orcid: bool = False
+    email: bool = False
+
+
+class AIIntegrations(BaseModel):
+    openai: bool = False
+    anthropic: bool = False
+
+
+class FeatureFlags(BaseModel):
+    auth_mechanisms: AuthMechanisms = AuthMechanisms()
+    ai_integrations: AIIntegrations = AIIntegrations()
+    email_notifications: bool = False
+
+
+FEATURE_FLAGS: FeatureFlags = FeatureFlags()
+"""The global feature flags object.
+
+This is a singleton of `FeatureFlags` that can be used to see
+the enabled features of the app at a higher-level to the
+configuration (e.g., includes runtime environment checks).
+"""

--- a/pydatalab/pydatalab/main.py
+++ b/pydatalab/pydatalab/main.py
@@ -49,7 +49,7 @@ def _check_feature_flags(app):
             )
             FEATURE_FLAGS.email_notifications = False
 
-        if CONFIG.EMAIL_DOMAIN_ALLOW_LIST:
+        if CONFIG.EMAIL_DOMAIN_ALLOW_LIST and FEATURE_FLAGS.email_notifications:
             FEATURE_FLAGS.auth_mechanisms.email = True
         else:
             LOGGER.warning(

--- a/pydatalab/pydatalab/routes/v0_1/info.py
+++ b/pydatalab/pydatalab/routes/v0_1/info.py
@@ -10,6 +10,7 @@ from pydantic import AnyUrl, BaseModel, Field, validator
 
 from pydatalab import __version__
 from pydatalab.blocks import BLOCK_TYPES
+from pydatalab.config import CONFIG, FEATURE_FLAGS, FeatureFlags
 from pydatalab.models import Person
 from pydatalab.mongo import flask_mongo
 
@@ -62,6 +63,7 @@ class Info(Attributes, Meta):
     homepage: Optional[AnyUrl]
     source_repository: Optional[AnyUrl]
     identifier_prefix: str
+    features: FeatureFlags = FEATURE_FLAGS
 
     @validator("maintainer")
     def strip_maintainer_fields(cls, v):
@@ -72,8 +74,6 @@ class Info(Attributes, Meta):
 
 @lru_cache(maxsize=1)
 def _get_deployment_metadata_once() -> Dict:
-    from pydatalab.config import CONFIG
-
     identifier_prefix = CONFIG.IDENTIFIER_PREFIX
     metadata = (
         CONFIG.DEPLOYMENT_METADATA.dict(exclude_none=True) if CONFIG.DEPLOYMENT_METADATA else {}
@@ -84,6 +84,10 @@ def _get_deployment_metadata_once() -> Dict:
 
 @INFO.route("/info", methods=["GET"])
 def get_info():
+    """Returns the runtime metadata for the deployment, e.g.,
+    versions, features and so on.
+
+    """
     metadata = _get_deployment_metadata_once()
 
     return (

--- a/pydatalab/tests/server/test_info_and_health.py
+++ b/pydatalab/tests/server/test_info_and_health.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 
 
@@ -7,6 +9,18 @@ def test_info_endpoint(client, url_prefix):
     assert response.status_code == 200
     assert all(k in response.json for k in ("data", "meta", "links"))
     assert all(k in response.json["data"] for k in ("type", "id", "attributes"))
+    attributes = response.json["data"]["attributes"]
+    assert (features := attributes.get("features"))
+    assert (auth := features.get("auth_mechanisms"))
+    assert auth["github"] is bool(
+        os.environ.get("GITHUB_OAUTH_CLIENT_ID", None)
+        and os.environ.get("GITHUB_OAUTH_CLIENT_SECRET", None)
+    )
+    assert auth["orcid"] is bool(
+        os.environ.get("ORCID_OAUTH_CLIENT_ID", None)
+        and os.environ.get("ORCID_OAUTH_CLIENT_SECRET", None)
+    )
+    assert auth["email"] is bool(os.environ.get("MAIL_PASSWORD", None))
 
 
 @pytest.mark.parametrize("url_prefix", ["", "/v0", "/v0.1", "/v0.1.0"])

--- a/webapp/src/components/LoginDetails.vue
+++ b/webapp/src/components/LoginDetails.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="row justify-content-center pt-3">
     <GetEmailModal v-model="emailModalIsOpen" />
-    <template v-if="currentUser != null">
+    <template v-if="user != null">
       <div class="dropdown">
         <button
           id="userDropdown"
@@ -12,7 +12,7 @@
           data-toggle="dropdown"
           @click="isUserDropdownVisible = !isUserDropdownVisible"
         >
-          <UserBubbleLogin :creator="currentUserInfo" :size="24" />&nbsp;
+          <UserBubbleLogin :creator="user" :size="24" />&nbsp;
           <span class="user-display-name">{{ userDisplayName }}</span
           >&nbsp;
         </button>
@@ -33,7 +33,7 @@
             ><font-awesome-icon icon="cog" /> &nbsp;&nbsp;Account settings
             <span v-if="isUnverified"><NotificationDot /></span>
           </a>
-          <span v-if="currentUserInfo.role === 'admin'">
+          <span v-if="user.role === 'admin'">
             <router-link
               to="/admin"
               class="dropdown-item btn login btn-link btn-default"
@@ -52,6 +52,7 @@
           >
         </div>
       </div>
+      <EditAccountSettingsModal v-model="editAccountSettingIsOpen" />
     </template>
     <template v-else>
       <div class="dropdown">
@@ -98,7 +99,6 @@
       </div>
     </template>
   </div>
-  <EditAccountSettingsModal v-model="editAccountSettingIsOpen" />
 
   <div v-if="isUnverified" class="container mt-4 mb-0 alert alert-warning text-center">
     Your account is currently unverified, and you will be unable to make or edit entries. Please
@@ -130,8 +130,7 @@ export default {
       isUserDropdownVisible: false,
       emailModalIsOpen: false,
       apiUrl: API_URL,
-      currentUser: null,
-      currentUserInfo: {},
+      user: null,
       editAccountSettingIsOpen: false,
     };
   },
@@ -166,17 +165,12 @@ export default {
         window.location.href = this.apiUrl + "/login/email?token=" + token;
       }
 
-      let user = await getUserInfo();
-      if (user != null) {
-        this.currentUser = user.display_name;
-        this.currentUserInfo = {
-          display_name: user.display_name || "",
-          immutable_id: user.immutable_id,
-          contact_email: user.contact_email || "",
-          role: user.role || "",
-          account_status: user.account_status || "",
-        };
-        this.$store.commit("setIsUnverified", user.account_status == "unverified" ? true : false);
+      this.user = await getUserInfo();
+      if (this.user != null) {
+        this.$store.commit(
+          "setIsUnverified",
+          this.user.account_status == "unverified" ? true : false,
+        );
       }
     },
   },

--- a/webapp/src/components/LoginDetails.vue
+++ b/webapp/src/components/LoginDetails.vue
@@ -75,6 +75,7 @@
         >
           <a
             type="button"
+            :class="{ disabled: !showGitHub }"
             class="dropdown-item btn login btn-link btn-default"
             aria-label="Login via GitHub"
             :href="apiUrl + '/login/github'"
@@ -82,6 +83,7 @@
           >
           <a
             type="button"
+            :class="{ disabled: !showORCID }"
             class="dropdown-item btn login btn-link btn-default"
             aria-label="Login via ORCID"
             :href="apiUrl + '/login/orcid'"
@@ -89,6 +91,7 @@
           >
           <button
             type="button"
+            :class="{ disabled: !showEmail }"
             class="dropdown-item btn login btn-link btn-default"
             aria-label="Login via email"
             @click="emailModalIsOpen = true"
@@ -110,7 +113,7 @@
 import { API_URL } from "@/resources.js";
 import UserBubbleLogin from "@/components/UserBubbleLogin.vue";
 import NotificationDot from "@/components/NotificationDot.vue";
-import { getUserInfo } from "@/server_fetch_utils.js";
+import { getUserInfo, getInfo } from "@/server_fetch_utils.js";
 import GetEmailModal from "@/components/GetEmailModal.vue";
 import EditAccountSettingsModal from "@/components/EditAccountSettingsModal.vue";
 
@@ -144,6 +147,15 @@ export default {
     hasUnverifiedUser() {
       return this.$store.getters.getHasUnverifiedUser;
     },
+    showGitHub() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.github ?? false;
+    },
+    showORCID() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.orcid ?? false;
+    },
+    showEmail() {
+      return this.$store.state.serverInfo?.features?.auth_mechanisms?.email ?? false;
+    },
   },
   watch: {
     modelValue(newValue) {
@@ -154,8 +166,11 @@ export default {
       }
     },
   },
-  mounted() {
+  async mounted() {
     this.getUser();
+    if (this.$store.state.serverInfo == null) {
+      getInfo();
+    }
   },
   methods: {
     async getUser() {

--- a/webapp/src/components/UserTable.vue
+++ b/webapp/src/components/UserTable.vue
@@ -130,6 +130,7 @@ export default {
     },
     async updateUserStatus(user_id, status) {
       await saveUser(user_id, { account_status: status });
+      this.users = JSON.parse(JSON.stringify(getUsersList()));
       this.original_users = JSON.parse(JSON.stringify(this.users));
     },
   },

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -538,10 +538,7 @@ export function saveUser(user_id, user) {
   fetch_patch(`${API_URL}/users/${user_id}`, user)
     .then(function (response_json) {
       if (response_json.status === "success") {
-        if (user.account_status) {
-          getUserInfo();
-          getUsersList();
-        }
+        getUserInfo();
         console.log("Save successful!");
       } else {
         alert("User save unsuccessful", response_json.detail);

--- a/webapp/src/server_fetch_utils.js
+++ b/webapp/src/server_fetch_utils.js
@@ -191,7 +191,8 @@ export async function getStats() {
 export async function getInfo() {
   return fetch_get(`${API_URL}/info`)
     .then(function (response_json) {
-      return { apiVersion: response_json.data.attributes.server_version };
+      store.commit("setServerInfo", response_json.data.attributes);
+      return response_json.data.attributes;
     })
     .catch((error) => {
       console.error("Error when fetching info");

--- a/webapp/src/store/index.js
+++ b/webapp/src/store/index.js
@@ -27,11 +27,16 @@ export default createStore({
     remoteDirectoryTreeIsLoading: false,
     fileSelectModalIsOpen: false,
     currentUserDisplayName: null,
+    serverInfo: null,
     blocksInfos: {},
     currentUserIsUnverified: false,
     hasUnverifiedUser: false,
   },
   mutations: {
+    setServerInfo(state, serverInfo) {
+      // set the server metadata
+      state.serverInfo = serverInfo;
+    },
     setSampleList(state, sampleSummaries) {
       // sampleSummaries is an array of json objects summarizing the available samples
       state.sample_list = sampleSummaries;

--- a/webapp/src/views/About.vue
+++ b/webapp/src/views/About.vue
@@ -29,7 +29,7 @@
             <tr>
               <td>API version</td>
               <td>
-                <code>{{ apiInfo.apiVersion }}</code>
+                <code>{{ apiInfo?.server_version ?? "unknown" }}</code>
               </td>
             </tr>
             <tr>
@@ -80,11 +80,14 @@ export default {
   components: { Navbar, StatisticsTable },
   data() {
     return {
-      apiInfo: { apiVersion: "unknown" },
+      apiInfo: { server_version: "unknown" },
     };
   },
   async mounted() {
-    this.apiInfo = await getInfo();
+    this.apiInfo = this.$store.state.serverInfo;
+    if (this.apiInfo == null) {
+      this.apiInfo = await getInfo();
+    }
   },
 };
 </script>


### PR DESCRIPTION
to e.g., disable unconfigured login mechanisms, and more in future.

This PR also tidies up the login details slightly, preventing duplicated calls to `/get-current-user` when not rendering the account settings block.